### PR TITLE
int to int32_t

### DIFF
--- a/ignore_words_spellcheck
+++ b/ignore_words_spellcheck
@@ -1,2 +1,3 @@
 endcode
 deque
+overflowin

--- a/include/CircuitGenGenerator/OrientedGraph.hpp
+++ b/include/CircuitGenGenerator/OrientedGraph.hpp
@@ -394,7 +394,7 @@ public:
       const std::string& i_name         = "",
       const bool&        i_addSubGraphs = false
   ) const;
-  std::vector<VertexPtr> getVerticesByLevel(const int32_t& i_level);
+  std::vector<VertexPtr> getVerticesByLevel(const uint32_t& i_level);
 
   std::vector<VertexPtr> getVerticesByName(
       const std::string& i_name,

--- a/include/CircuitGenGenerator/OrientedGraph.hpp
+++ b/include/CircuitGenGenerator/OrientedGraph.hpp
@@ -145,12 +145,12 @@ public:
   ///  OrientedGraph graph("ExampleGraph");
   /// // Add vertices and edges to the graph (omitted for brevity)
   /// // Calculate the maximum level of output vertices
-  /// unsigned maxLevel = graph.getMaxLevel();
+  /// uint32_t maxLevel = graph.getMaxLevel();
   /// // Output the result
   /// std::cout << "Maximum level of output vertices: " << maxLevel << '\n';
   /// @endcode
 
-  unsigned                  getMaxLevel();
+  uint32_t                  getMaxLevel();
 
   /// @brief addParentGraph
   /// Adds a parent graph to the current graph

--- a/include/CircuitGenGenerator/OrientedGraph.hpp
+++ b/include/CircuitGenGenerator/OrientedGraph.hpp
@@ -86,7 +86,7 @@ public:
   /// @return An integer value representing the number of "gate" type vertices
   /// in the graph
 
-  int                       baseSize() const;
+  size_t                    baseSize() const;
   // Количество gate в графе, включая подграфы
   /// @brief fullSize returns the total number of vertices in the graph,
   /// including vertices from all subgraphs. It recursively traverses all
@@ -94,7 +94,7 @@ public:
   /// @return An integer value representing the total number of vertices
   /// in the graph, including vertices from all subgraphs
 
-  int                       fullSize() const;
+  size_t                    fullSize() const;
   // sum of gates, inputs, outputs and consts sizes
   /// @brief sumFullSize returns the total number of vertices of all types
   /// in the graph, including input vertices, constants, gates, and output
@@ -277,7 +277,7 @@ public:
   /// auto subGraph = std::make_shared<OrientedGraph>("SubGraph");
   /// // Create input vertices for the subgraph
   /// std::vector<VertexPtr> subGraphInputs;
-  /// for (int i = 0; i < 3; ++i)
+  /// for (size_t i = 0; i < 3; ++i)
   /// {
   ///   auto inputVertex = graph->addInput("SubGraphInput" +
   ///   std::to_string(i+1)); subGraphInputs.push_back(inputVertex);
@@ -334,7 +334,7 @@ public:
   /// auto graph = std::make_shared<OrientedGraph>("ExampleGraph");
   /// // Create multiple source vertices
   /// std::vector<VertexPtr> sources;
-  /// for (int i = 0; i < 3; ++i)
+  /// for (size_t i = 0; i < 3; ++i)
   /// {
   ///   auto vertex = graph->addInput("Source" + std::to_string(i+1));
   ///   sources.push_back(vertex);
@@ -365,7 +365,7 @@ public:
   std::set<GraphPtr>                            getSubGraphs() const;
   std::set<GraphPtr>                            getSetSubGraphs() const;
   std::map<VertexTypes, std::vector<VertexPtr>> getBaseVertexes() const;
-  VertexPtr   getVerticeByIndex(int idx) const;
+  VertexPtr   getVerticeByIndex(size_t idx) const;
 
   std::string getGraphInstance();
   std::pair<bool, std::string>
@@ -382,7 +382,7 @@ public:
   /// returns true.
 
   bool        toGraphML(std::ofstream& i_fileStream) const;
-  std::string toGraphML(int i_indent = 0, const std::string& i_prefix = "")
+  std::string toGraphML(uint16_t i_indent = 0, const std::string& i_prefix = "")
       const;
   // visualize
   // calcGraph
@@ -394,14 +394,14 @@ public:
       const std::string& i_name         = "",
       const bool&        i_addSubGraphs = false
   ) const;
-  std::vector<VertexPtr> getVerticesByLevel(const int& i_level);
+  std::vector<VertexPtr> getVerticesByLevel(const int32_t& i_level);
 
   std::vector<VertexPtr> getVerticesByName(
       const std::string& i_name,
       const bool&        i_addSubGraphs = false
   ) const;
 
-  bool                                  operator==(const OrientedGraph& rhs);
+  bool                    operator==(const OrientedGraph& rhs);
 
   /// @brief calculateHash calculates hash values for a graph based on the hash
   /// values of its vertices
@@ -410,14 +410,14 @@ public:
   /// By default, false.
   /// @return A string representing the hash value of the graph
 
-  std::string                           calculateHash(bool recalculate = false);
+  std::string             calculateHash(bool recalculate = false);
 
   // @brief getGatesCount Returns a display containing the number of each gate
   /// type in the graph
   /// @return A display where each key is a type of gate (Gates), and the
   /// corresponding value is the number of gates of this type in the graph
 
-  std::map<Gates, int>                  getGatesCount() const;
+  std::map<Gates, size_t> getGatesCount() const;
 
   /// @brief getEdgesGatesCount Returns a mapping containing the number of
   /// edges between different types of gates in the graph
@@ -425,7 +425,7 @@ public:
   /// corresponding value is an internal mapping containing the number of
   /// edges between different types of gates in the graph
 
-  std::map<Gates, std::map<Gates, int>> getEdgesGatesCount() const;
+  std::map<Gates, std::map<Gates, size_t>> getEdgesGatesCount() const;
 
 private:
   static std::atomic_size_t  d_countNewGraphInstance;
@@ -468,7 +468,7 @@ private:
   static std::atomic_size_t d_countGraph;
 
   // used for quick gates count
-  std::map<Gates, int>      d_gatesCount = {
+  std::map<Gates, size_t>   d_gatesCount = {
       {Gates::GateAnd, 0},
       {Gates::GateNand, 0},
       {Gates::GateOr, 0},
@@ -478,7 +478,7 @@ private:
       {Gates::GateXor, 0},
       {Gates::GateXnor, 0}};
   // used for quick edges of gate type count;
-  std::map<Gates, std::map<Gates, int>> d_edgesGatesCount;
+  std::map<Gates, std::map<Gates, size_t>> d_edgesGatesCount;
 
   std::shared_ptr<Settings> d_settings = Settings::getInstance("OrientedGraph");
 };

--- a/src/CircuitGenGenerator.cpp
+++ b/src/CircuitGenGenerator.cpp
@@ -47,8 +47,8 @@ void runGeneration(
     // Задаем сид рандомизации.
     AuxMethods::setRandSeed(
         !data.contains("seed") || data["seed"] == -1
-            ? static_cast<unsigned>(std::time(0))
-            : static_cast<unsigned>(data["seed"])
+            ? static_cast<uint_fast32_t>(std::time(0))
+            : static_cast<uint_fast32_t>(data["seed"])
     );
     // EVERYWHERE seed from json is getting here. It is like a storage for seed
     // for all future usages`

--- a/src/CircuitGenGenerator.cpp
+++ b/src/CircuitGenGenerator.cpp
@@ -95,15 +95,15 @@ void runGeneration(
                                  ? static_cast<std::string>(data["dataset_id"])
                                  : "0";
 
-    int         requestIdINT = data.contains("id") ? (int)data["id"] : 0;
+    uint32_t         requestIdINT = data.contains("id") ? (uint32_t)data["id"] : 0;
 
     std::string requestId    = std::to_string(requestIdINT);
 
-    int         minInputs    = 1;
-    int         maxInputs    = 1;
-    int         minOutputs   = 1;
-    int         maxOutputs   = 1;
-    int         repeats      = 1;
+    uint32_t         minInputs    = 1;
+    uint32_t         maxInputs    = 1;
+    uint32_t         minOutputs   = 1;
+    uint32_t         maxOutputs   = 1;
+    uint32_t         repeats      = 1;
 
     if (data.contains("min_in")) {
       minInputs = data["min_in"];
@@ -152,12 +152,12 @@ void runGeneration(
         data.contains("make_graphml") ? (bool)data["make_graphml"] : false;
 
     // Считывание информации по логичсеким элементам.
-    std::map<std::string, std::vector<int>> gatesInputsInfo;
+    std::map<std::string, std::vector<int32_t>> gatesInputsInfo;
 
     if (data.contains("gates_inputs_info")) {
       for (auto gate : data["gates_inputs_info"].items()) {
-        std::vector<int> gatesNumber =
-            static_cast<std::vector<int>>(gate.value());
+        std::vector<int32_t> gatesNumber =
+            static_cast<std::vector<int32_t>>(gate.value());
 
         // sorting data. It's important for fast generator work
         if (gatesNumber.size()) {
@@ -221,10 +221,10 @@ void runGeneration(
                      "Parameters sets to default."
                   << std::endl;
 
-      int minLevel   = data.contains("min_level") ? (int)data["min_level"] : 0;
-      int maxLevel   = data.contains("max_level") ? (int)data["max_level"] : 0;
-      int minElement = data.contains("min_elem") ? (int)data["min_elem"] : 0;
-      int maxElement = data.contains("max_elem") ? (int)data["max_elem"] : 0;
+      uint32_t minLevel   = data.contains("min_level") ? (uint32_t)data["min_level"] : 0;
+      uint32_t maxLevel   = data.contains("max_level") ? (uint32_t)data["max_level"] : 0;
+      uint32_t minElement = data.contains("min_elem") ? (uint32_t)data["min_elem"] : 0;
+      uint32_t maxElement = data.contains("max_elem") ? (uint32_t)data["max_elem"] : 0;
       gp.setRandLevelParameters(minLevel, maxLevel, minElement, maxElement);
     }
 
@@ -252,7 +252,7 @@ void runGeneration(
           {"xnor", Gates::GateXnor}
       };
 
-      std::map<Gates, int> m;
+      std::map<Gates, int32_t> m;
 
       for (auto& el : data.items()) {
         if (std::find(v.begin(), v.end(), el.key()) != v.end()) {
@@ -271,9 +271,9 @@ void runGeneration(
 
     // Основные параметры для Genetic
     if (data["type_of_generation"] == "Genetic") {
-      int numOfSurv = 1;
+      int32_t numOfSurv = 1;
       if (data.contains("surv_num"))
-        int numOfSurv = data["surv_num"];
+        int32_t numOfSurv = data["surv_num"];
       else
         std::clog << "Parameter surv_num is not set." << std::endl;
 
@@ -308,7 +308,7 @@ void runGeneration(
       else
         std::clog << "Parameter mutChance is not set." << std::endl;
 
-      int exchangeType = 0;
+      int32_t exchangeType = 0;
       if (data.contains("swap_type"))
         exchangeType = data["swap_type"];
       else
@@ -326,19 +326,19 @@ void runGeneration(
       else
         std::clog << "Parameter ratio_in_table is not set." << std::endl;
 
-      int recNum = 1;
+      int32_t recNum = 1;
       if (data.contains("rec_num"))
         recNum = data["rec_num"];
       else
         std::clog << "Parameter rec_num is not set." << std::endl;
 
-      int refPoints = 1;
+      int32_t refPoints = 1;
       if (data.contains("ref_points"))
         refPoints = data["ref_points"];
       else
         std::clog << "Parameter ref_points is not set." << std::endl;
 
-      int tourSize = 1;
+      int32_t tourSize = 1;
       if (data.contains("tour_size"))
         tourSize = data["tour_size"];
       else
@@ -384,13 +384,13 @@ void runGeneration(
       else
         std::clog << "Parameter mask_prob is not set." << std::endl;
 
-      int populationSize = 1;
+      int32_t populationSize = 1;
       if (data.contains("population_size"))
         populationSize = data["population_size"];
       else
         std::clog << "Parameter population_size is not set." << std::endl;
 
-      int numOfCycles = 1;
+      int32_t numOfCycles = 1;
       if (data.contains("cycles"))
         numOfCycles = data["cycles"];
       else
@@ -401,7 +401,7 @@ void runGeneration(
       if (selectionType == "Base")
         selType = SelectionTypes::Base;
 
-      int survNum = data["surv_num"];
+      int32_t survNum = data["surv_num"];
 
       gp.setPopulationSize(populationSize);
       gp.setNumOfCycles(numOfCycles);
@@ -492,10 +492,10 @@ void runGeneration(
       bool RNL        = data.contains("RNL") ? (bool)data["RNL"] : false;
       bool NUM_OP     = data.contains("NUM_OP") ? (bool)data["NUM_OP"] : false;
       // для RNL
-      int  minLevel   = data.contains("min_level") ? (int)data["min_level"] : 0;
-      int  maxLevel   = data.contains("max_level") ? (int)data["max_level"] : 0;
-      int  minElement = data.contains("min_elem") ? (int)data["min_elem"] : 0;
-      int  maxElement = data.contains("max_elem") ? (int)data["max_elem"] : 0;
+      uint32_t  minLevel   = data.contains("min_level") ? (uint32_t)data["min_level"] : 0;
+      uint32_t  maxLevel   = data.contains("max_level") ? (uint32_t)data["max_level"] : 0;
+      uint32_t  minElement = data.contains("min_elem") ? (uint32_t)data["min_elem"] : 0;
+      uint32_t  maxElement = data.contains("max_elem") ? (uint32_t)data["max_elem"] : 0;
       // для NUM_OP
       std::vector<std::string> v = {
           "num_and",
@@ -517,7 +517,7 @@ void runGeneration(
           {"xor", Gates::GateXor},
           {"xnor", Gates::GateXnor}
       };
-      std::map<Gates, int> m;
+      std::map<Gates, int32_t> m;
       bool                 LeaveEmptyOut = false;
       if (data.contains("leave_empty_out"))
         LeaveEmptyOut = data["leave_empty_out"];

--- a/src/additional/AuxiliaryMethods.cpp
+++ b/src/additional/AuxiliaryMethods.cpp
@@ -42,7 +42,7 @@ std::uint_fast32_t AuxMethods::getRandSeed() {
   return gen.getSeed();
 }
 
-int AuxMethods::getRandInt(int lower, int upper, bool inclusively) {
+int32_t AuxMethods::getRandInt(int32_t lower, int32_t upper, bool inclusively) {
   return gen.getRandInt(lower, upper, inclusively);
 }
 
@@ -68,11 +68,11 @@ std::string AuxMethods::readAllFile(const std::string& filename) {
   return buffer.str();
 }
 
-std::vector<int> AuxMethods::getRandomIntList(
-    int  i_n,
-    int  i_minNumber,
-    int  i_maxNumber,
-    bool repite
+std::vector<int32_t> AuxMethods::getRandomIntList(
+    size_t  i_n,
+    int32_t i_minNumber,
+    int32_t i_maxNumber,
+    bool    repite
 ) {
   return gen.getRandomIntList(i_n, i_minNumber, i_maxNumber, repite);
 }
@@ -122,16 +122,21 @@ template std::vector<std::vector<VertexPtr>> AuxMethods::transpose(
 // explicit instantiation of sortDictByValue
 // if you want to use this func with other types, just add corresponding
 // instantiation below, compilation error otherwise.
-template std::vector<std::pair<int, int>>
-    AuxMethods::sortDictByValue(const std::map<int, int>& i_dict, bool up);
-
-template std::vector<std::pair<int, double>>
-    AuxMethods::sortDictByValue(const std::map<int, double>& i_dict, bool up);
-
-template std::vector<std::pair<std::string, int>> AuxMethods::sortDictByValue(
-    const std::map<std::string, int>& i_dict,
+template std::vector<std::pair<int32_t, int32_t>> AuxMethods::sortDictByValue(
+    const std::map<int32_t, int32_t>& i_dict,
     bool                              up
 );
+
+template std::vector<std::pair<int32_t, double>> AuxMethods::sortDictByValue(
+    const std::map<int32_t, double>& i_dict,
+    bool                             up
+);
+
+template std::vector<std::pair<std::string, int32_t>>
+    AuxMethods::sortDictByValue(
+        const std::map<std::string, int32_t>& i_dict,
+        bool                                  up
+    );
 
 std::string AuxMethods::removeSpaces(const std::string& i_s) {
   std::string res = "";
@@ -142,8 +147,8 @@ std::string AuxMethods::removeSpaces(const std::string& i_s) {
   return res;
 }
 
-int AuxMethods::skipSpaces(const std::string& i_s, int i_start) {
-  int res = i_start;
+size_t AuxMethods::skipSpaces(const std::string& i_s, size_t i_start) {
+  size_t res = i_start;
   while (res < i_s.size()
          && (i_s[res] == ' ' || i_s[res] == '\t' || i_s[res] == '\n'
              || i_s[res] == '\r'))
@@ -151,9 +156,10 @@ int AuxMethods::skipSpaces(const std::string& i_s, int i_start) {
   return res;
 }
 
-std::string AuxMethods::intToStringWithZeroes(int i_num, int i_totalDigits) {
-  int numLength = std::to_string(i_num).length();
-  i_totalDigits = std::max(numLength, i_totalDigits);
+std::string
+    AuxMethods::intToStringWithZeroes(uint32_t i_num, size_t i_totalDigits) {
+  size_t numLength = std::to_string(i_num).length();
+  i_totalDigits    = std::max(numLength, i_totalDigits);
   std::stringstream ss;
   ss << std::setw(i_totalDigits) << std::setfill('0') << i_num;
   return ss.str();

--- a/src/additional/AuxiliaryMethods.hpp
+++ b/src/additional/AuxiliaryMethods.hpp
@@ -47,11 +47,11 @@ std::uint_fast32_t getRandSeed();
 /// @return A random integer in the specified range
 /// @code
 /// Generating a random number in the range [1, 100] inclusive
-/// int randomNumber = AuxMethods::getRandInt(1, 100, true);
+/// uint32_t randomNumber = AuxMethods::getRandInt(1, 100, true);
 /// //randomNumber = 45;
 /// @endcode
 
-int                getRandInt(int lower, int upper, bool inclusively = false);
+int32_t     getRandInt(int32_t lower, int32_t upper, bool inclusively = false);
 
 // @brief getRandDouble Returns a random floating point number in the
 /// specified range
@@ -64,7 +64,7 @@ int                getRandInt(int lower, int upper, bool inclusively = false);
 /// // randomNumber = 0.35;
 /// @endcode
 
-double             getRandDouble(double lower, double upper);
+double      getRandDouble(double lower, double upper);
 
 /// @brief readAllFile Reads the contents of the file and returns it as a
 /// string
@@ -79,7 +79,7 @@ double             getRandDouble(double lower, double upper);
 /// @endcode
 /// @throws std::runtime_error if the file cannot be opened
 
-std::string        readAllFile(const std::string& filename);
+std::string readAllFile(const std::string& filename);
 
 /// @brief getRandomIntList Generates a list of random integers in a given
 /// range with certain restrictions on the number of elements and the
@@ -91,12 +91,12 @@ std::string        readAllFile(const std::string& filename);
 /// numbers
 /// @param repite A flag indicating whether the repetition of numbers in
 /// the list is allowed (true - allowed, false - not allowed). Default - false
-/// @return a vector<int> of random numbers according to the specified
+/// @return a vector<uint32_t> of random numbers according to the specified
 /// parameters
 /// @code
-/// std::vector<int>  randomList = getRandomIntList(10, 1, 100, false);
+/// std::vector<uint32_t>  randomList = getRandomIntList(10, 1, 100, false);
 /// std::cout << "Random list without repetition: ";
-/// for (int num : randomList)
+/// for (uint32_t num : randomList)
 /// {
 ///     std::cout << num << " ";
 /// }
@@ -104,12 +104,12 @@ std::string        readAllFile(const std::string& filename);
 /// // and they are all different.
 /// @endcode
 
-std::vector<int>   getRandomIntList(
-      int  i_n,
-      int  i_minNumber,
-      int  i_maxNumber,
-      bool repite = false
-  );
+std::vector<int32_t> getRandomIntList(
+    size_t  i_n,
+    int32_t i_minNumber,
+    int32_t i_maxNumber,
+    bool    repite = false
+);
 
 /// @brief sortDictByValue Sorting the associative container by values and
 /// returning sorted key-value pairs as a vector. Sorting can be performed both
@@ -123,12 +123,12 @@ std::vector<int>   getRandomIntList(
 /// @return A vector of key-value pairs containing dictionary elements sorted
 /// by values
 /// @code
-/// std::map<std::string, int> myDict;
+/// std::map<std::string, int32_t> myDict;
 /// myDict["apple"]  = 5;
 /// myDict["banana"] = 3;
 /// myDict["orange"] = 7;
 /// // Sorting the dictionary by values in ascending order
-/// std::vector<std::pair<std::string, int>> sortedPairs =
+/// std::vector<std::pair<std::string, int32_t>> sortedPairs =
 /// AuxMethods::sortDictByValue(myDict, true);
 
 /// // Output sorted key-value pairs
@@ -169,9 +169,9 @@ std::string removeSpaces(const std::string& i_s);
 /// index outside the line,
 /// @code
 /// std::string str = "    \t\nHello, world!";
-/// int startIndex    = 0;
+/// size_t startIndex    = 0;
 /// // Skip the whitespace characters in the string
-/// int nonSpaceIndex = AuxMethods::skipSpaces(str, startIndex);
+/// size_t nonSpaceIndex = AuxMethods::skipSpaces(str, startIndex);
 /// // Output the result
 /// if (nonSpaceIndex < str.size())
 /// {
@@ -186,14 +186,14 @@ std::string removeSpaces(const std::string& i_s);
 /// }
 /// @endcode
 
-int         skipSpaces(const std::string& i_s, int i_start = 0);
+size_t      skipSpaces(const std::string& i_s, size_t i_start = 0);
 
 template<typename T>
 std::vector<std::vector<T>> transpose(const std::vector<std::vector<T>>& matrix
 );
 
 // TODO: if need CopyDirectory
-std::string intToStringWithZeroes(int i_num, int i_totalDigits = 5);
+std::string intToStringWithZeroes(uint32_t i_num, size_t i_totalDigits = 5);
 
 std::string replacer(const std::string& i_s, const std::string& i_r);
 

--- a/src/additional/RandomGeneratorWithSeed.hpp
+++ b/src/additional/RandomGeneratorWithSeed.hpp
@@ -52,7 +52,7 @@ public:
   /// @return dis The generated integer in the range between lower and upper
   /// */
 
-  int getRandInt(int lower, int upper, bool inclusively = false) {
+  int32_t getRandInt(int32_t lower, int32_t upper, bool inclusively = false) {
     if (!inclusively)
       upper--;
 
@@ -70,25 +70,25 @@ public:
     return dis(d_gen);
   }
 
-  std::vector<int> getRandomIntList(
-      int  i_n,
-      int  i_minNumber,
-      int  i_maxNumber,
-      bool repite = false
+  std::vector<int32_t> getRandomIntList(
+      size_t  i_n,
+      int32_t i_minNumber,
+      int32_t i_maxNumber,
+      bool    repite = false
   ) {
-    std::vector<int> randomNumbers;
+    std::vector<int32_t> randomNumbers;
 
     if (repite) {
       // Если повторения разрешены, просто генерируем числа.
-      for (int i = 0; i < i_n; ++i) {
+      for (size_t i = 0; i < i_n; ++i) {
         randomNumbers.push_back(getRandInt(i_minNumber, i_maxNumber, false));
       }
     } else {
       // Если повторения запрещены, используем set для проверки существующих
       // чисел.
-      std::unordered_set<int> used;
-      while (randomNumbers.size() < static_cast<size_t>(i_n)) {
-        int number = getRandInt(i_minNumber, i_maxNumber, false);
+      std::unordered_set<int32_t> used;
+      while (randomNumbers.size() < i_n) {
+        int32_t number = getRandInt(i_minNumber, i_maxNumber, false);
         // Добавляем только уникальные числа.
         if (used.insert(number).second) {
           randomNumbers.push_back(number);

--- a/src/additional/filesTools/FilesTools.cpp
+++ b/src/additional/filesTools/FilesTools.cpp
@@ -7,8 +7,8 @@ std::vector<std::string> getDirectories(std::string& path) {
   for (const auto& file : std::filesystem::directory_iterator(path)) {
     if (std::filesystem::is_directory(file)) {
       std::string path      = file.path().string();
-      int         lastSlash = 0;
-      for (int i = 0; i < path.size(); ++i) {
+      size_t      lastSlash = 0;
+      for (size_t i = 0; i < path.size(); ++i) {
         if (path[i] == std::filesystem::path::preferred_separator) {
           lastSlash = i + 1;
         }

--- a/src/baseStructures/Parser.cpp
+++ b/src/baseStructures/Parser.cpp
@@ -23,16 +23,16 @@ std::string deleteDoubleSpaces(const std::string& s) {
 }  // namespace
 
 Parser::Parser(
-    const std::string&                             i_logExpression,
-    const std::map<std::string, std::vector<int>>& i_info
+    const std::string&                                 i_logExpression,
+    const std::map<std::string, std::vector<int32_t>>& i_info
 ) {
   d_logExpressions.push_back(deleteDoubleSpaces(i_logExpression));
   setGatesInputsInfo(i_info);
 }
 
 Parser::Parser(
-    const std::vector<std::string>&                i_logExpressions,
-    const std::map<std::string, std::vector<int>>& i_info
+    const std::vector<std::string>&                    i_logExpressions,
+    const std::map<std::string, std::vector<int32_t>>& i_info
 ) {
   for (const auto& expression : i_logExpressions)
     d_logExpressions.push_back(expression);
@@ -60,7 +60,7 @@ GraphPtr Parser::getGraph() const {
 }
 
 void Parser::setGatesInputsInfo(
-    const std::map<std::string, std::vector<int>>& i_info
+    const std::map<std::string, std::vector<int32_t>>& i_info
 ) {
   for (auto& [key, value] : i_info) {
     d_gatesInputsInfo[d_settings->parseStringToGate(key)] = value;
@@ -171,7 +171,7 @@ std::pair<int32_t, std::vector<std::string>> Parser::splitLogicExpression(
             i_expr   = deleteExtraSpaces(i_expr.substr(index + oper.length()));
             brackets = createBrackets(i_expr);
 
-            int idx  = i_expr.find(oper);
+            size_t idx = i_expr.find(oper);
             // now we are trying to parse whole operations
             if (idx != std::string::npos && !inBrackets(brackets.second, idx)) {
               index = idx;
@@ -230,7 +230,7 @@ VertexPtr Parser::multipleVerteciesToOne(
 
         // if we have less elements than we can add, and our logical element
         // has too big gates number, move to lower
-        int npos = pos;
+        int64_t npos = pos;
         while (npos >= 0 && curSize < d_gatesInputsInfo[operation][npos]) {
           --npos;
         }
@@ -246,7 +246,7 @@ VertexPtr Parser::multipleVerteciesToOne(
     if (curSize > 1) {
       // if we have less elements than we can add, and our logical element
       // has too big gates number, move to lower
-      int npos = pos;
+      int64_t npos = pos;
       while (npos >= 0 && curSize < d_gatesInputsInfo[operation][npos]) {
         --npos;
       }

--- a/src/baseStructures/Parser.hpp
+++ b/src/baseStructures/Parser.hpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include <CircuitGenGenerator/OrientedGraph.hpp>
-using GatesInfo = std::map<Gates, std::vector<int>>;
+using GatesInfo = std::map<Gates, std::vector<int32_t>>;
 
 /// class Parser
 /// @param d_logExpressions It can represent a set of logical expressions
@@ -27,12 +27,12 @@ using GatesInfo = std::map<Gates, std::vector<int>>;
 class Parser {
 public:
   Parser(
-      const std::string&                             i_logExpression,
-      const std::map<std::string, std::vector<int>>& i_info
+      const std::string&                                 i_logExpression,
+      const std::map<std::string, std::vector<int32_t>>& i_info
   );
   Parser(
-      const std::vector<std::string>&                i_logExpressions,
-      const std::map<std::string, std::vector<int>>& i_info
+      const std::vector<std::string>&                    i_logExpressions,
+      const std::map<std::string, std::vector<int32_t>>& i_info
   );
 
   Parser(const std::string& i_logExpression, const GatesInfo& i_info);
@@ -126,13 +126,14 @@ public:
   /// @param i_info A map where keys are gate names as strings and values are
   /// vectors of integers specifying the number of inputs for each gate
 
-  void setGatesInputsInfo(const std::map<std::string, std::vector<int>>& i_info
-  );
+  void      setGatesInputsInfo(
+           const std::map<std::string, std::vector<int32_t>>& i_info
+       );
 
   /// @brief setGatesInputsInfo
   /// TO DO:
   /// Analog setGatesInputsInfo
-  /// @param GatesInfo = std::map<Gates, std::vector<int>>
+  /// @param GatesInfo = std::map<Gates, std::vector<int32_t>>
   void setGatesInputsInfo(const GatesInfo& i_info);
 
 private:

--- a/src/baseStructures/graph/GraphMLTemplates.hpp
+++ b/src/baseStructures/graph/GraphMLTemplates.hpp
@@ -16,5 +16,5 @@ const char* rawNodeTemplate  = R"(%    <node id="%">
 %    </node>
 )";
 
-const char* rawEdgeTemplate  = R"(%    <source="%" target="%"/>
+const char* rawEdgeTemplate  = R"(%    <edge source="%" target="%"/>
 )";

--- a/src/baseStructures/graph/GraphVertex.hpp
+++ b/src/baseStructures/graph/GraphVertex.hpp
@@ -100,7 +100,7 @@ private:
 };
 
 /// class GraphVertexSubGraph It is a class, having a subGruph pointer
-/// inside. Is used for storing this pointer for providing Grpah
+/// inside. Is used for storing this pointer for providing graph
 /// connectivity
 /// @param d_subGraph Pointer to the subgraph associated with this vertex
 /// @param hashed Cached hash value of the vertex
@@ -122,7 +122,7 @@ public:
   /// OrientedGraph methods
   /// @param i_path path to future file storing. Do not add submodule here,
   /// folder would be created there
-  /// @param i_filename name of file to be created (default is same as grpah
+  /// @param i_filename name of file to be created (default is same as graph
   /// name)
   /// @return pair, first is bool, meaning was file writing successful or not
   /// and second is string, for graph is empty, for subgraph is module instance

--- a/src/baseStructures/graph/GraphVertex.hpp
+++ b/src/baseStructures/graph/GraphVertex.hpp
@@ -139,7 +139,7 @@ public:
   /// OrientedGraph methods
   /// @param i_indent
   /// @return
-  std::string toGraphML(int i_indent = 0, std::string i_prefix = "") const;
+  std::string toGraphML(uint16_t i_indent = 0, std::string i_prefix = "") const;
 
   /// @brief This method is used as a substructure for
   /// OrientedGraph methods

--- a/src/baseStructures/graph/GraphVertexBase.cpp
+++ b/src/baseStructures/graph/GraphVertexBase.cpp
@@ -134,12 +134,12 @@ std::vector<VertexPtrWeak> GraphVertexBase::getInConnections() const {
   return d_inConnections;
 }
 
-int GraphVertexBase::addVertexToInConnections(VertexPtr i_vert) {
+uint32_t GraphVertexBase::addVertexToInConnections(VertexPtr i_vert) {
   VertexPtrWeak vertWeak(i_vert);
 
   d_inConnections.push_back(vertWeak);
-  int n = 0;
-  // TODO use map<VertexPtr, int> instead of for
+  uint32_t n = 0;
+  // TODO use map<VertexPtr, uint32_t> instead of for
   for (VertexPtrWeak vert : d_inConnections)
     n += (vert.lock() == i_vert);
   return n;
@@ -178,13 +178,13 @@ bool GraphVertexBase::removeVertexToInConnections(
 
   if (i_full) {
     bool f = false;
-    for (int i = d_inConnections.size() - 1; i >= 0; i--) {
+    for (int64_t i = d_inConnections.size() - 1; i >= 0; i--) {
       d_inConnections.erase(d_inConnections.begin() + i);
       f = true;
     }
     return f;
   } else {
-    for (int i = 0; i < d_inConnections.size(); i++) {
+    for (size_t i = 0; i < d_inConnections.size(); i++) {
       d_inConnections.erase(d_inConnections.begin() + i);
       return true;
     }
@@ -197,7 +197,7 @@ std::vector<VertexPtr> GraphVertexBase::getOutConnections() const {
 }
 
 bool GraphVertexBase::addVertexToOutConnections(VertexPtr i_vert) {
-  int n = 0;
+  size_t n = 0;
   for (VertexPtr vert : d_outConnections)
     n += (vert == i_vert);
   if (n == 0) {
@@ -208,7 +208,7 @@ bool GraphVertexBase::addVertexToOutConnections(VertexPtr i_vert) {
 }
 
 bool GraphVertexBase::removeVertexToOutConnections(VertexPtr i_vert) {
-  for (int i = 0; i < d_outConnections.size(); i++) {
+  for (size_t i = 0; i < d_outConnections.size(); i++) {
     d_outConnections.erase(d_outConnections.begin() + i);
     return true;
   }

--- a/src/baseStructures/graph/GraphVertexBase.cpp
+++ b/src/baseStructures/graph/GraphVertexBase.cpp
@@ -104,11 +104,11 @@ std::string GraphVertexBase::getName(const std::string& i_prefix) const {
   return i_prefix + d_name;
 }
 
-void GraphVertexBase::setLevel(const unsigned i_level) {
+void GraphVertexBase::setLevel(const uint32_t i_level) {
   d_level = i_level;
 }
 
-unsigned GraphVertexBase::getLevel() const {
+uint32_t GraphVertexBase::getLevel() const {
   return d_level;
 }
 

--- a/src/baseStructures/graph/GraphVertexBase.hpp
+++ b/src/baseStructures/graph/GraphVertexBase.hpp
@@ -69,7 +69,7 @@ std::string vertexTypeToComment(VertexTypes i_type);
 /// @param i_name The name of the vertex. It is a string containing the name
 /// of a vertex
 /// @param d_value The value of the vertex
-/// @param d_level The vertex level is represented by the unsigned type
+/// @param d_level The vertex level is represented by the uint32_t type
 /// @param d_inConnections vector of weak pointers to input connections with
 /// other vertices
 /// @param d_outConnections vector of strong pointers to output connections
@@ -190,18 +190,18 @@ public:
   /// std::cout << "New level of the vertex: " << vertex.getLevel() << '\n';
   /// @endcode
 
-  void                       setLevel(const unsigned i_level);
+  void                       setLevel(const uint32_t i_level);
 
   /// @brief getLevel
   /// Returns the level of the vertex
   /// @return The level of the vertex
   /// @code
   /// GraphVertexBase vertex(VertexTypes::input, "vertex1");
-  /// unsigned level = vertex.getLevel();
+  /// uint32_t level = vertex.getLevel();
   /// std::cout << "Level of the vertex: " << level << std::endl;
   /// @endcode
 
-  unsigned                   getLevel() const;
+  uint32_t                   getLevel() const;
 
   /// @brief updateLevel
   /// This method updates the level of the vertex based on the levels of its

--- a/src/baseStructures/graph/GraphVertexBase.hpp
+++ b/src/baseStructures/graph/GraphVertexBase.hpp
@@ -475,7 +475,7 @@ protected:
 
   std::string                d_name;
   char                       d_value;
-  unsigned                   d_level;
+  uint32_t                   d_level;
 
   std::vector<VertexPtrWeak> d_inConnections;
   std::vector<VertexPtr>     d_outConnections;

--- a/src/baseStructures/graph/GraphVertexBase.hpp
+++ b/src/baseStructures/graph/GraphVertexBase.hpp
@@ -277,7 +277,7 @@ public:
   /// std::make_shared<GraphVertexBase>(VertexTypes::input, "vertex2");
   /// // Add the second vertex to the input connections of the first vertex
   /// // and get the number of occurrences
-  /// int count = vertex.addVertexToInConnections(anotherVertex);
+  /// uint32_t count = vertex.addVertexToInConnections(anotherVertex);
   /// // Output the result
   /// std::cout << "The number of occurrences of the second vertex in the input
   /// connections of the first vertex: " << count << std::endl;
@@ -297,13 +297,13 @@ public:
   /// std::make_shared<GraphVertexBase>(VertexTypes::input, "vertex2");
   /// // Adding a second vertex to the input connections of the first vertex
   /// and getting the number of occurrences
-  /// int occurrences = vertex.addVertexToInConnections(anotherVertex);
+  /// uint32_t occurrences = vertex.addVertexToInConnections(anotherVertex);
   /// // Output of the result
   /// std::cout << "The number of occurrences of the second vertex in the input
   /// connections of the first vertex: " << occurrences << std::endl;
   /// @endcode
 
-  int                        addVertexToInConnections(VertexPtr i_vert);
+  uint32_t                   addVertexToInConnections(VertexPtr i_vert);
 
   /// @brief removeVertexToInConnections
   /// Removes a vertex from the input connections of this vertex.

--- a/src/baseStructures/graph/GraphVertexGates.cpp
+++ b/src/baseStructures/graph/GraphVertexGates.cpp
@@ -34,7 +34,7 @@ char GraphVertexGates::updateValue() {
       d_value = tableBuf.at(ptr->getValue());
     if (d_gate == Gates::GateNot)
       d_value = tableNot.at(ptr->getValue());
-    for (int i = 1; i < d_inConnections.size(); i++) {
+    for (size_t i = 1; i < d_inConnections.size(); i++) {
       switch (d_gate) {
         case (Gates::GateAnd):
           table = tableAnd.at(d_value);
@@ -114,7 +114,7 @@ std::string GraphVertexGates::getVerilogString() const {
         || (d_gate == Gates::GateXnor))
       s = "~(" + s;
 
-    for (int i = 1; i < d_inConnections.size(); i++) {
+    for (size_t i = 1; i < d_inConnections.size(); i++) {
       // check if ptr is alive
       if (!(ptr = d_inConnections[i].lock())) {
         throw std::invalid_argument("Dead pointer!");

--- a/src/baseStructures/graph/GraphVertexInput.cpp
+++ b/src/baseStructures/graph/GraphVertexInput.cpp
@@ -25,7 +25,7 @@ char GraphVertexInput::updateValue() {
         return 'x';
       }
 
-      for (int i = 1; i < d_inConnections.size(); i++) {
+      for (size_t i = 1; i < d_inConnections.size(); i++) {
         if (auto ptr = d_inConnections[i].lock()) {
           if (ptr->getValue() != d_value) {
             d_value = 'x';

--- a/src/baseStructures/graph/GraphVertexOutput.cpp
+++ b/src/baseStructures/graph/GraphVertexOutput.cpp
@@ -17,7 +17,7 @@ char GraphVertexOutput::updateValue() {
       throw std::invalid_argument("Dead pointer!");
     }
   }
-  for (int i = 1; i < d_inConnections.size(); i++) {
+  for (size_t i = 1; i < d_inConnections.size(); i++) {
     if (auto ptr = d_inConnections[i].lock()) {
       if (ptr->getValue() != d_value) {
         d_value = 'x';

--- a/src/baseStructures/graph/GraphVertexSubGraph.cpp
+++ b/src/baseStructures/graph/GraphVertexSubGraph.cpp
@@ -44,8 +44,10 @@ bool GraphVertexSubGraph::toGraphML(std::ofstream& i_fileStream) const {
   return d_subGraph->toGraphML(i_fileStream);
 }
 
-std::string GraphVertexSubGraph::toGraphML(int i_indent, std::string i_prefix)
-    const {
+std::string GraphVertexSubGraph::toGraphML(
+    uint16_t    i_indent,
+    std::string i_prefix
+) const {
   return d_subGraph->toGraphML(i_indent, i_prefix);
 }
 

--- a/src/baseStructures/graph/OrientedGraph.cpp
+++ b/src/baseStructures/graph/OrientedGraph.cpp
@@ -31,12 +31,12 @@ OrientedGraph::OrientedGraph(const std::string& i_name) {
 
 OrientedGraph::~OrientedGraph() {}
 
-int OrientedGraph::baseSize() const {
+size_t OrientedGraph::baseSize() const {
   return d_vertexes.at(VertexTypes::gate).size();
 }
 
-int OrientedGraph::fullSize() const {
-  int size = this->baseSize();
+size_t OrientedGraph::fullSize() const {
+  size_t size = this->baseSize();
   for (GraphPtr vert : d_subGraphs)
     size += vert->fullSize();
   return size;
@@ -225,8 +225,8 @@ std::map<VertexTypes, std::vector<VertexPtr>> OrientedGraph::getBaseVertexes(
   return d_vertexes;
 }
 
-VertexPtr OrientedGraph::getVerticeByIndex(int idx) const {
-  if (sumFullSize() <= idx || idx < 0)
+VertexPtr OrientedGraph::getVerticeByIndex(size_t idx) const {
+  if (sumFullSize() <= idx)
     throw std::invalid_argument("OrientedGraph getVerticeByIndex: invalid index"
     );
 
@@ -249,7 +249,8 @@ VertexPtr OrientedGraph::getVerticeByIndex(int idx) const {
   return d_vertexes.at(VertexTypes::output).at(idx);
 }
 
-std::vector<VertexPtr> OrientedGraph::getVerticesByLevel(const int& i_level) {
+std::vector<VertexPtr> OrientedGraph::getVerticesByLevel(const int32_t& i_level
+) {
   this->updateLevels();
   std::vector<VertexPtr> a;
   // TODO: Реализовать
@@ -305,11 +306,11 @@ size_t OrientedGraph::sumFullSize() const {
        + d_vertexes.at(VertexTypes::subGraph).size();
 }
 
-std::map<Gates, int> OrientedGraph::getGatesCount() const {
+std::map<Gates, size_t> OrientedGraph::getGatesCount() const {
   return d_gatesCount;
 }
 
-std::map<Gates, std::map<Gates, int>> OrientedGraph::getEdgesGatesCount(
+std::map<Gates, std::map<Gates, size_t>> OrientedGraph::getEdgesGatesCount(
 ) const {
   return d_edgesGatesCount;
 }
@@ -538,8 +539,10 @@ std::pair<bool, std::string>
   return std::make_pair(true, "");
 }
 
-std::string OrientedGraph::toGraphML(int i_indent, const std::string& i_prefix)
-    const {
+std::string OrientedGraph::toGraphML(
+    uint16_t           i_indent,
+    const std::string& i_prefix
+) const {
   using namespace AuxMethods;  // format() and replacer()
 
   const std::string spaces(i_indent, ' ');

--- a/src/baseStructures/graph/OrientedGraph.cpp
+++ b/src/baseStructures/graph/OrientedGraph.cpp
@@ -177,8 +177,8 @@ std::vector<VertexPtr> OrientedGraph::addSubGraph(
 }
 
 bool OrientedGraph::addEdge(VertexPtr from, VertexPtr to) {
-  bool f;
-  int  n;
+  bool     f;
+  uint32_t n;
   if (from->getBaseGraph().lock() == to->getBaseGraph().lock()) {
     f = from->addVertexToOutConnections(to);
     n = to->addVertexToInConnections(from);

--- a/src/baseStructures/graph/OrientedGraph.cpp
+++ b/src/baseStructures/graph/OrientedGraph.cpp
@@ -78,9 +78,9 @@ void OrientedGraph::updateLevels() {
   // }
 }
 
-unsigned OrientedGraph::getMaxLevel() {
+uint32_t OrientedGraph::getMaxLevel() {
   this->updateLevels();
-  unsigned mx = 0;
+  uint32_t mx = 0;
   for (VertexPtr vert : d_vertexes.at(VertexTypes::output)) {
     mx = mx < vert->getLevel() ? mx : vert->getLevel();
   }

--- a/src/baseStructures/graph/OrientedGraph.cpp
+++ b/src/baseStructures/graph/OrientedGraph.cpp
@@ -249,7 +249,7 @@ VertexPtr OrientedGraph::getVerticeByIndex(size_t idx) const {
   return d_vertexes.at(VertexTypes::output).at(idx);
 }
 
-std::vector<VertexPtr> OrientedGraph::getVerticesByLevel(const int32_t& i_level
+std::vector<VertexPtr> OrientedGraph::getVerticesByLevel(const uint32_t& i_level
 ) {
   this->updateLevels();
   std::vector<VertexPtr> a;

--- a/src/baseStructures/truthTable/TruthTable.cpp
+++ b/src/baseStructures/truthTable/TruthTable.cpp
@@ -13,7 +13,7 @@ TruthTable::TruthTable() {
   d_settings = Settings::getInstance("TruthTable");
 }
 
-TruthTable::TruthTable(int i_seed) {
+TruthTable::TruthTable(uint_fast32_t i_seed) {
   d_randGenerator.setSeed(i_seed);
   d_settings = Settings::getInstance("TruthTable");
 }
@@ -24,13 +24,13 @@ TruthTable::TruthTable(int i_seed) {
 //     d_settings = Settings::getInstance("TruthTable");
 // }
 
-void TruthTable::setSeed(int i_seed) {
+void TruthTable::setSeed(uint_fast32_t i_seed) {
   d_randGenerator.setSeed(i_seed);
 }
 
 TruthTable::TruthTable(
-    int                                   i_input,
-    int                                   i_output,
+    int32_t                               i_input,
+    int32_t                               i_output,
     const std::vector<std::vector<bool>>& i_array
 ) :
   d_input(i_input), d_output(i_output) {
@@ -57,7 +57,7 @@ TruthTable::TruthTable(
   }
 }
 
-TruthTable::TruthTable(int i_input, int i_output, double i_p) :
+TruthTable::TruthTable(int32_t i_input, int32_t i_output, double i_p) :
   d_input(i_input), d_output(i_output) {
   d_size = (1u << i_input);
   generateTable(i_p);
@@ -65,8 +65,8 @@ TruthTable::TruthTable(int i_input, int i_output, double i_p) :
 
 std::vector<std::vector<bool>> TruthTable::convToBinary() const {
   std::vector<std::vector<bool>> bin(d_size, std::vector<bool>(d_input));
-  for (int i = 0; i < d_size; ++i) {
-    for (int j = d_input - 1, tmp = i; j >= 0; --j) {
+  for (int32_t i = 0; i < d_size; ++i) {
+    for (int32_t j = d_input - 1, tmp = i; j >= 0; --j) {
       bin[i][j] = (tmp % 2) == 1;
       tmp       /= 2;
     }
@@ -74,15 +74,15 @@ std::vector<std::vector<bool>> TruthTable::convToBinary() const {
   return bin;
 }
 
-int TruthTable::getInput() const {
+int32_t TruthTable::getInput() const {
   return d_input;
 }
 
-int TruthTable::getOutput() const {
+int32_t TruthTable::getOutput() const {
   return d_output;
 }
 
-int TruthTable::size() const {
+int32_t TruthTable::size() const {
   return d_size;
 }
 
@@ -90,7 +90,7 @@ std::vector<std::vector<bool>> TruthTable::getOutTable() const {
   return d_array;
 }
 
-bool TruthTable::getOutTable(int i, int j) const {
+bool TruthTable::getOutTable(int32_t i, int32_t j) const {
   return d_array.at(i).at(j);
 }
 
@@ -109,9 +109,9 @@ void TruthTable::generateRandom(TruthTableParameters i_gp) {
   d_array.clear();
   d_array.resize(d_size);
 
-  for (int i = 0; i < d_size; ++i) {
+  for (int32_t i = 0; i < d_size; ++i) {
     d_array[i].resize(i_gp.getOutputs());
-    for (int j = 0; j < i_gp.getOutputs(); ++j)
+    for (int32_t j = 0; j < i_gp.getOutputs(); ++j)
       d_array[i][j] = d_randGenerator.getRandInt(0, 1, true) == 1;
   }
 }
@@ -120,9 +120,9 @@ void TruthTable::generateTable(double i_p) {
   if (i_p <= 0) {
     d_array.clear();
     d_array.resize(d_size);
-    for (int i = 0; i < d_size; ++i) {
+    for (int32_t i = 0; i < d_size; ++i) {
       d_array[i].resize(d_output);
-      for (int j = 0; j < d_output; ++j)
+      for (int32_t j = 0; j < d_output; ++j)
         d_array[i][j] = d_randGenerator.getRandInt(0, 1, true) == 1;
     }
     return;
@@ -130,9 +130,9 @@ void TruthTable::generateTable(double i_p) {
   if (i_p > 0 && i_p <= 1) {
     d_array.clear();
     d_array.resize(d_size);
-    for (int i = 0; i < d_size; ++i) {
+    for (int32_t i = 0; i < d_size; ++i) {
       d_array[i].resize(d_output);
-      for (int j = 0; j < d_output; ++j)
+      for (int32_t j = 0; j < d_output; ++j)
         d_array[i][j] = AuxMethods::getRandDouble(0, 1) < i_p;
     }
     return;

--- a/src/baseStructures/truthTable/TruthTable.hpp
+++ b/src/baseStructures/truthTable/TruthTable.hpp
@@ -22,21 +22,21 @@ class TruthTable {
 public:
   TruthTable();
 
-  TruthTable(int seed);
+  TruthTable(uint_fast32_t seed);
   // TruthTable(const TruthTable& other)            = default;
   TruthTable& operator=(const TruthTable& other) = default;
   TruthTable(TruthTable&& other)                 = default;
   TruthTable& operator=(TruthTable&& other)      = default;
   TruthTable(
-      int                                   i_input,
-      int                                   i_output,
+      int32_t                               i_input,
+      int32_t                               i_output,
       const std::vector<std::vector<bool>>& i_array = {}
   );
   TruthTable(
       const TruthTable&              i_tt,
       std::vector<std::vector<bool>> i_array = {}
   );
-  TruthTable(int i_input, int i_output, double i_p = 0.5);
+  TruthTable(int32_t i_input, int32_t i_output, double i_p = 0.5);
 
   /// @brief setSeed
   /// Set the seed for random number generation.
@@ -51,7 +51,7 @@ public:
   /// For the getSeed method there is getSeed in RandomGeneratorWithSeed.hpp
   /// @see RandomGeneratorWithSeed
 
-  void                           setSeed(int i_seed);
+  void                           setSeed(uint_fast32_t i_seed);
   // void generateRandom(TruthTableParameters i_gp) override;
 
   /// @brief generateTable The method generates a truth table for a
@@ -78,22 +78,22 @@ public:
   /// @return The number of input variables.
   /// @code
   /// TruthTable table;
-  /// int numInputs = table.getInput();
+  /// int32_t numInputs = table.getInput();
   /// std::cout << "Number of input variables: " << numInputs << std::endl;
   /// @endcode
 
-  int                            getInput() const;
+  int32_t                        getInput() const;
 
   /// @brief getOutput
   /// Get the number of output variables in the truth table
   /// @return The number of output variables.
   /// @code
   /// TruthTable table;
-  /// int numOutputs = table.getOutput();
+  /// int32_t numOutputs = table.getOutput();
   /// std::cout << "Number of output variables: " << numOutputs << std::endl;
   /// @endcode
 
-  int                            getOutput() const;
+  int32_t                        getOutput() const;
 
   /// @brief size
   /// Get the size of the truth table.
@@ -103,11 +103,11 @@ public:
   /// @code
   /// // Creating a truth table with 3 input variables and 2 output variables
   /// TruthTable table (3,2);
-  /// int tableSize = table.size();
+  /// int32_t tableSize = table.size();
   /// std::cout << "Size of the truth table: " << tableSize << std::endl;
   /// @endcode
 
-  int                            size() const;
+  int32_t                        size() const;
 
   /// @brief getOutTable
   /// Get the output table.
@@ -150,7 +150,7 @@ public:
   /// bool value = table.getOutTable(1,0);
   /// @endcode
 
-  bool                           getOutTable(int i, int j) const;
+  bool                           getOutTable(int32_t i, int32_t j) const;
 
   /// @brief convToBinary
   /// Convert truth table indices to binary representation
@@ -200,9 +200,9 @@ public:
   bool                           operator==(const TruthTable& r) const;
 
 private:
-  int                            d_input;
-  int                            d_output;
-  int                            d_size;
+  int32_t                        d_input;
+  int32_t                        d_output;
+  int32_t                        d_size;
   std::vector<std::vector<bool>> d_array;
   std::shared_ptr<Settings> d_settings = Settings::getInstance("TruthTable");
   RandomGeneratorWithSeed   d_randGenerator;

--- a/src/circuit/Circuit.cpp
+++ b/src/circuit/Circuit.cpp
@@ -159,16 +159,16 @@ bool Circuit::graphToVerilog(const std::string& i_path, bool i_pathExists) {
   static std::string filename;
   static std::string s;
 
-  int                previousSizeOfFileName = filename.size();
+  size_t             previousSizeOfFileName = filename.size();
 
   if (!d_graph->getSubGraphs().empty()) {
     std::string folderSubgraphs = d_path + "/submodules";
     std::filesystem::create_directory(folderSubgraphs);
   }
-  filename = d_path + "/" + d_circuitName + ".v";
+  filename    = d_path + "/" + d_circuitName + ".v";
 
-  int pos  = (s.find_last_of('/')) + 1;
-  int pos2 = (filename.find_last_of('/')) + 1;
+  size_t pos  = (s.find_last_of('/')) + 1;
+  size_t pos2 = (filename.find_last_of('/')) + 1;
 
   if (previousSizeOfFileName == 0)
     s = std::filesystem::current_path().string() + "/"

--- a/src/circuit/Circuit.hpp
+++ b/src/circuit/Circuit.hpp
@@ -159,7 +159,7 @@ public:
   /// vertex
   /// */
 
-  void    setVerticeOperation(int i_vertice, const std::string& i_operation);
+  void setVerticeOperation(int32_t i_vertice, const std::string& i_operation);
 
   /// @todo: description fromVerilog
   /// @brief fromVerilog

--- a/src/circuit/CircuitParameters.hpp
+++ b/src/circuit/CircuitParameters.hpp
@@ -40,16 +40,16 @@ public:
   CircuitParameters()                                               = default;
 
   /// @todo: rewrite getters and setters
-  std::string                                        d_name         = "";
-  int                                                d_numInputs    = 0;
-  int                                                d_numConstants = 0;
-  int                                                d_numOutputs   = 0;
-  unsigned                                           d_maxLevel     = 0;
-  int                                                d_numEdges     = 0;
-  int                                                d_numGates     = 0;
-  double                                             d_size         = 0.;
-  double                                             d_area         = 0.;
-  std::string                                        d_hashCode     = "";
-  std::map<std::string, int>                         d_numElementsOfEachType;
-  std::map<std::pair<std::string, std::string>, int> d_numEdgesOfEachType;
+  std::string                                           d_name      = "";
+  uint32_t                                              d_numInputs = 0;
+  uint32_t                                              d_numConstants = 0;
+  uint32_t                                              d_numOutputs   = 0;
+  uint32_t                                              d_maxLevel     = 0;
+  uint32_t                                              d_numEdges     = 0;
+  uint32_t                                              d_numGates     = 0;
+  double                                                d_size         = 0.;
+  double                                                d_area         = 0.;
+  std::string                                           d_hashCode     = "";
+  std::map<std::string, size_t>                         d_numElementsOfEachType;
+  std::map<std::pair<std::string, std::string>, size_t> d_numEdgesOfEachType;
 };

--- a/src/database/DataBaseGenerator.cpp
+++ b/src/database/DataBaseGenerator.cpp
@@ -112,7 +112,7 @@ void DataBaseGenerator::runGeneratorByDefault(
           );
 
           GenerationParameters param = d_parameters.getGenerationParameters();
-          param.setSeed(*iter);
+          param.setSeed(*iter + i + j);
 
           generator(param);
 

--- a/src/database/DataBaseGenerator.cpp
+++ b/src/database/DataBaseGenerator.cpp
@@ -78,14 +78,14 @@ void DataBaseGenerator::runGeneratorByDefault(
 
   ThreadPool pool(parallel);
 
-  for (int i = i_dbgp.getMinInputs(); i <= i_dbgp.getMaxInputs(); ++i) {
-    for (int j = i_dbgp.getMinOutputs(); j <= i_dbgp.getMaxOutputs(); ++j) {
+  for (int32_t i = i_dbgp.getMinInputs(); i <= i_dbgp.getMaxInputs(); ++i) {
+    for (int32_t j = i_dbgp.getMinOutputs(); j <= i_dbgp.getMaxOutputs(); ++j) {
       auto iter = seeds.begin();
       d_parameters.setInputs(i);
       d_parameters.setOutputs(j);
 
       if (parallel > 1) {
-        for (int tt = 0; tt < i_dbgp.getEachIteration(); ++tt) {
+        for (int32_t tt = 0; tt < i_dbgp.getEachIteration(); ++tt) {
           d_parameters.setIteration(tt);
           d_parameters.setName(
               d_settings->getGenerationMethodPrefix(gt)
@@ -103,7 +103,7 @@ void DataBaseGenerator::runGeneratorByDefault(
           ++iter;
         }
       } else {
-        for (int tt = 0; tt < i_dbgp.getEachIteration(); ++tt) {
+        for (int32_t tt = 0; tt < i_dbgp.getEachIteration(); ++tt) {
           // TODO: it is that Rustam told about iteration?
           d_parameters.setIteration(tt);
           d_parameters.setName(
@@ -319,7 +319,7 @@ void DataBaseGenerator::generateDataBaseSummator(
   SimpleGenerators sg(i_param.getSeed());
   sg.setGatesInputsInfo(i_param.getGatesInputsInfo());
 
-  int      bits        = i_param.getInputs();
+  int32_t  bits        = i_param.getInputs();
   bool     overflowIn  = i_param.getSummator().getOverFlowIn();
   bool     overflowOut = i_param.getSummator().getOverFlowOut();
   bool     minus       = i_param.getSummator().getMinus();
@@ -338,7 +338,7 @@ void DataBaseGenerator::generateDataBaseComparison(
   SimpleGenerators sg(i_param.getSeed());
   sg.setGatesInputsInfo(i_param.getGatesInputsInfo());
 
-  int      i_bits   = i_param.getInputs();
+  int32_t  i_bits   = i_param.getInputs();
   bool     compare0 = i_param.getComparison().getCompare0();
   bool     compare1 = i_param.getComparison().getCompare1();
   bool     compare2 = i_param.getComparison().getCompare2();
@@ -357,7 +357,7 @@ void DataBaseGenerator::generateDataBaseEncoder(
   SimpleGenerators sg(i_param.getSeed());
   sg.setGatesInputsInfo(i_param.getGatesInputsInfo());
 
-  int      i_bits = i_param.getInputs();
+  int32_t  i_bits = i_param.getInputs();
   GraphPtr graph  = sg.generatorEncoder(i_bits);
   Circuit  c(graph);
   c.setPath(d_mainPath);
@@ -373,7 +373,7 @@ void DataBaseGenerator::generateDataBaseParity(
   SimpleGenerators sg(i_param.getSeed());
   sg.setGatesInputsInfo(i_param.getGatesInputsInfo());
 
-  int      bits  = i_param.getInputs();
+  int32_t  bits  = i_param.getInputs();
   GraphPtr graph = sg.generatorParity(bits);
   Circuit  c(graph);
   c.setPath(d_mainPath);
@@ -409,7 +409,7 @@ void DataBaseGenerator::generateDataBaseMultiplexer(
   SimpleGenerators sg(i_param.getSeed());
   sg.setGatesInputsInfo(i_param.getGatesInputsInfo());
 
-  int      i_bits = i_param.getInputs();
+  int32_t  i_bits = i_param.getInputs();
   GraphPtr graph  = sg.generatorMultiplexer(i_bits);
   Circuit  c(graph);
   c.setPath(d_mainPath);
@@ -425,7 +425,7 @@ void DataBaseGenerator::generateDataBaseDemultiplexer(
   SimpleGenerators sg(i_param.getSeed());
   sg.setGatesInputsInfo(i_param.getGatesInputsInfo());
 
-  int      i_bits = i_param.getOutputs();
+  int32_t  i_bits = i_param.getOutputs();
   GraphPtr graph  = sg.generatorDemultiplexer(i_bits);
   Circuit  c(graph);
   c.setPath(d_mainPath);

--- a/src/database/DataBaseGenerator.hpp
+++ b/src/database/DataBaseGenerator.hpp
@@ -84,7 +84,7 @@ private:
   std::shared_ptr<Settings> d_settings =
       Settings::getInstance("DataBaseGenerator");
   DataBaseGeneratorParameters d_parameters;  // why we need this var?
-  int                         d_dirCount = 0;
+  int32_t                     d_dirCount = 0;
 
   /// @brief generateDataBaseFromRandomTruthTable The generate DataBase From
   /// Random Truth Table method of the DataBase Generator class is responsible

--- a/src/database/DataBaseGeneratorParameters.cpp
+++ b/src/database/DataBaseGeneratorParameters.cpp
@@ -1,11 +1,11 @@
 #include "DataBaseGeneratorParameters.hpp"
 
 DataBaseGeneratorParameters::DataBaseGeneratorParameters(
-    int                  i_minInputs,
-    int                  i_maxInputs,
-    int                  i_minOutputs,
-    int                  i_maxOutputs,
-    int                  i_eachIteration,
+    uint32_t             i_minInputs,
+    uint32_t             i_maxInputs,
+    uint32_t             i_minOutputs,
+    uint32_t             i_maxOutputs,
+    uint32_t             i_eachIteration,
     GenerationTypes      i_gt,
     GenerationParameters i_gp
 ) :
@@ -17,15 +17,15 @@ DataBaseGeneratorParameters::DataBaseGeneratorParameters(
   d_generationTypes(i_gt),
   d_generationParameters(i_gp) {};
 
-void DataBaseGeneratorParameters::setInputs(int i_inputs) {
+void DataBaseGeneratorParameters::setInputs(uint32_t i_inputs) {
   d_generationParameters.setInputs(i_inputs);
 }
 
-void DataBaseGeneratorParameters::setOutputs(int i_outputs) {
+void DataBaseGeneratorParameters::setOutputs(uint32_t i_outputs) {
   d_generationParameters.setOutputs(i_outputs);
 }
 
-void DataBaseGeneratorParameters::setIteration(int i_iteration) {
+void DataBaseGeneratorParameters::setIteration(uint32_t i_iteration) {
   d_generationParameters.setIteration(i_iteration);
 }
 
@@ -33,23 +33,23 @@ void DataBaseGeneratorParameters::setName(const std::string& i_name) {
   d_generationParameters.setName(i_name);
 }
 
-int DataBaseGeneratorParameters::getMinInputs() const {
+uint32_t DataBaseGeneratorParameters::getMinInputs() const {
   return d_minInputs;
 }
 
-int DataBaseGeneratorParameters::getMaxInputs() const {
+uint32_t DataBaseGeneratorParameters::getMaxInputs() const {
   return d_maxInputs;
 }
 
-int DataBaseGeneratorParameters::getMinOutputs() const {
+uint32_t DataBaseGeneratorParameters::getMinOutputs() const {
   return d_minOutputs;
 }
 
-int DataBaseGeneratorParameters::getMaxOutputs() const {
+uint32_t DataBaseGeneratorParameters::getMaxOutputs() const {
   return d_maxOutputs;
 }
 
-int DataBaseGeneratorParameters::getEachIteration() const {
+uint32_t DataBaseGeneratorParameters::getEachIteration() const {
   return d_eachIteration;
 }
 

--- a/src/database/DataBaseGeneratorParameters.hpp
+++ b/src/database/DataBaseGeneratorParameters.hpp
@@ -22,11 +22,11 @@
 class DataBaseGeneratorParameters {
 public:
   DataBaseGeneratorParameters(
-      int                  i_minInputs,
-      int                  i_maxInputs,
-      int                  i_minOutputs,
-      int                  i_maxOutputs,
-      int                  i_eachIteration,
+      uint32_t             i_minInputs,
+      uint32_t             i_maxInputs,
+      uint32_t             i_minOutputs,
+      uint32_t             i_maxOutputs,
+      uint32_t             i_eachIteration,
       GenerationTypes      i_gt,
       GenerationParameters i_gp
   );
@@ -37,7 +37,7 @@ public:
   /// that must be set to generate the database
   /// */
 
-  void                 setInputs(int i_inputs);
+  void                 setInputs(uint32_t i_inputs);
 
   /// @brief setOutputs The method sets the number of output signals to generate
   /// the database
@@ -45,7 +45,7 @@ public:
   /// signals that must be set to generate the database
   /// */
 
-  void                 setOutputs(int i_outputs);
+  void                 setOutputs(uint32_t i_outputs);
 
   /// @brief setIteration The method sets the iteration number for database
   /// generation
@@ -53,7 +53,7 @@ public:
   /// must be set to generate the database
   /// */
 
-  void                 setIteration(int i_iteration);
+  void                 setIteration(uint32_t i_iteration);
 
   /// @brief setName The method is used to set the name for database generation
   /// @param i_name A string containing the name to be set to generate the
@@ -67,28 +67,28 @@ public:
   /// @return Minimum number of inputs for database generation
   /// */
 
-  int                  getMinInputs() const;
+  uint32_t             getMinInputs() const;
 
   /// @brief getMaxInputs This method is used to get the maximum number of
   /// inputs set in the database generation parameters.
   /// @return Maximum number of inputs for database generation
   /// */
 
-  int                  getMaxInputs() const;
+  uint32_t             getMaxInputs() const;
 
   /// @brief getMinOutputs This method is used to get the minimum number of
   /// outputs set in the database generation parameters.
   /// @return The minimum number of outputs for database generation.
   /// */
 
-  int                  getMinOutputs() const;
+  uint32_t             getMinOutputs() const;
 
   /// @brief getMaxOutputs This one is used to get the maximum number of outputs
   /// set in the database generation parameters.
   /// @return Maximum number of outputs for database generation
   /// */
 
-  int                  getMaxOutputs() const;
+  uint32_t             getMaxOutputs() const;
 
   /// @brief getEachIteration This method is used to get the number of
   /// iterations that need to be performed for each combination of inputs and
@@ -97,7 +97,7 @@ public:
   /// outputs during database generation.
   /// */
 
-  int                  getEachIteration() const;
+  uint32_t             getEachIteration() const;
 
   /// @brief getGenerationParameters This method is used to get the database
   /// generation parameters
@@ -113,11 +113,11 @@ public:
   GenerationTypes      getGenerationType() const;
 
 private:
-  int             d_minInputs       = 0;
-  int             d_maxInputs       = 0;
-  int             d_minOutputs      = 0;
-  int             d_maxOutputs      = 0;
-  int             d_eachIteration   = 0;
+  uint32_t        d_minInputs       = 0;
+  uint32_t        d_maxInputs       = 0;
+  uint32_t        d_minOutputs      = 0;
+  uint32_t        d_maxOutputs      = 0;
+  uint32_t        d_eachIteration   = 0;
   GenerationTypes d_generationTypes = GenerationTypes::FromRandomTruthTable;
   GenerationParameters d_generationParameters;
 };

--- a/src/generators/GenerationParameters.hpp
+++ b/src/generators/GenerationParameters.hpp
@@ -55,27 +55,27 @@ private:
 
 class GeneratorRandLevelParameters {
 public:
-  int  getMinLevel() const { return d_minLevel; }
+  uint32_t getMinLevel() const { return d_minLevel; }
 
-  void setMinLevel(int i_minLevel) { d_minLevel = i_minLevel; }
+  void     setMinLevel(uint32_t i_minLevel) { d_minLevel = i_minLevel; }
 
-  int  getMaxLevel() const { return d_maxLevel; }
+  uint32_t getMaxLevel() const { return d_maxLevel; }
 
-  void setMaxLevel(int i_maxLevel) { d_maxLevel = i_maxLevel; }
+  void     setMaxLevel(uint32_t i_maxLevel) { d_maxLevel = i_maxLevel; }
 
-  int  getMinElements() const { return d_minElements; }
+  uint32_t getMinElements() const { return d_minElements; }
 
-  void setMinElements(int i_minElements) { d_minElements = i_minElements; }
+  void setMinElements(uint32_t i_minElements) { d_minElements = i_minElements; }
 
-  int  getMaxElements() const { return d_maxElements; }
+  uint32_t getMaxElements() const { return d_maxElements; }
 
-  void setMaxElements(int i_maxElements) { d_maxElements = i_maxElements; }
+  void setMaxElements(uint32_t i_maxElements) { d_maxElements = i_maxElements; }
 
 private:
-  int d_minLevel    = 0;
-  int d_maxLevel    = 0;
-  int d_minElements = 0;
-  int d_maxElements = 0;
+  uint32_t d_minLevel    = 0;
+  uint32_t d_maxLevel    = 0;
+  uint32_t d_minElements = 0;
+  uint32_t d_maxElements = 0;
 };
 
 /// class GeneratorNumOperationParameters
@@ -89,26 +89,26 @@ private:
 
 class GeneratorNumOperationParameters {
 public:
-  int getLogicOper(const Gates& i_op) const {
+  int32_t getLogicOper(const Gates& i_op) const {
     if (d_logicOper.find(i_op) != d_logicOper.end())
       return d_logicOper.at(i_op);
     return -1;
   }
 
-  std::map<Gates, int> getLogicOpers() const { return d_logicOper; }
-  void                 setLogicOper(const std::pair<Gates, int>& i_p) {
+  std::map<Gates, int32_t> getLogicOpers() const { return d_logicOper; }
+  void                     setLogicOper(const std::pair<Gates, int32_t>& i_p) {
     d_logicOper[i_p.first] = i_p.second;
   }
 
-  void setLogicOper(const std::map<Gates, int>& i_p) { d_logicOper = i_p; }
+  void setLogicOper(const std::map<Gates, int32_t>& i_p) { d_logicOper = i_p; }
 
   bool getLeaveEmptyOut() const { return d_leaveEmptyOut; }
 
   void setLeaveEmptyOut(bool i_leo) { d_leaveEmptyOut = i_leo; }
 
 private:
-  std::map<Gates, int> d_logicOper;
-  bool                 d_leaveEmptyOut = true;
+  std::map<Gates, int32_t> d_logicOper;
+  bool                     d_leaveEmptyOut = true;
 };
 
 /// GeneratorSummatorParameters
@@ -182,76 +182,76 @@ private:
 /// @todo: Desc class
 class GeneratorALUParameters {
 public:
-  bool                 getALL() { return d_ALL; }
-  bool                 getSUM() { return d_SUM; }
-  bool                 getSUB() { return d_SUB; }
-  bool                 getNSUM() { return d_NSUM; }
-  bool                 getNSUB() { return d_NSUB; }
-  bool                 getMULT() { return d_MULT; }
-  bool                 getCOM() { return d_COM; }
-  bool                 getAND() { return d_AND; }
-  bool                 getNAND() { return d_NAND; }
-  bool                 getOR() { return d_OR; }
-  bool                 getNOR() { return d_NOR; }
-  bool                 getXOR() { return d_XOR; }
-  bool                 getXNOR() { return d_XNOR; }
-  bool                 getCNF() { return d_CNF; }
-  bool                 getRNL() { return d_RNL; }
-  bool                 getNUMOP() { return d_NUM_OP; }
-  int                  getminLevel() { return d_minLevel; }
-  int                  getmaxLevel() { return d_maxLevel; }
-  int                  getminElement() { return d_minElement; }
-  int                  getmaxElement() { return d_maxElement; }
-  std::map<Gates, int> getm() { return d_m; }
-  bool                 getLeaveEmptyOut() { return d_LeaveEmptyOut; }
-  void                 setALL(bool i_ALL) { d_ALL = i_ALL; }
-  void                 setSUM(bool i_SUM) { d_SUM = i_SUM; }
-  void                 setSUB(bool i_SUB) { d_SUB = i_SUB; }
-  void                 setNSUM(bool i_NSUM) { d_NSUM = i_NSUM; }
-  void                 setNSUB(bool i_NSUB) { d_NSUB = i_NSUB; }
-  void                 setMULT(bool i_MULT) { d_MULT = i_MULT; }
-  void                 setCOM(bool i_COM) { d_COM = i_COM; }
-  void                 setAND(bool i_AND) { d_AND = i_AND; }
-  void                 setNAND(bool i_NAND) { d_NAND = i_NAND; }
-  void                 setOR(bool i_OR) { d_OR = i_OR; }
-  void                 setNOR(bool i_NOR) { d_NOR = i_NOR; }
-  void                 setXOR(bool i_XOR) { d_XOR = i_XOR; }
-  void                 setXNOR(bool i_XNOR) { d_XNOR = i_XNOR; }
-  void                 setCNF(bool i_CNF) { d_CNF = i_CNF; }
-  void                 setRNL(int i_RNL) { d_RNL = i_RNL; }
-  void                 setNUMOP(int i_NUM_OP) { d_NUM_OP = i_NUM_OP; }
-  void                 setminLevel(int i_minLevel) { d_minLevel = i_minLevel; }
-  void                 setmaxLevel(int i_maxLevel) { d_maxLevel = i_maxLevel; }
-  void setminElement(int i_minElement) { d_minElement = i_minElement; }
-  void setmaxElement(int i_maxElement) { d_maxElement = i_maxElement; }
-  void setm(std::map<Gates, int> i_m) { d_m = i_m; }
+  bool                     getALL() { return d_ALL; }
+  bool                     getSUM() { return d_SUM; }
+  bool                     getSUB() { return d_SUB; }
+  bool                     getNSUM() { return d_NSUM; }
+  bool                     getNSUB() { return d_NSUB; }
+  bool                     getMULT() { return d_MULT; }
+  bool                     getCOM() { return d_COM; }
+  bool                     getAND() { return d_AND; }
+  bool                     getNAND() { return d_NAND; }
+  bool                     getOR() { return d_OR; }
+  bool                     getNOR() { return d_NOR; }
+  bool                     getXOR() { return d_XOR; }
+  bool                     getXNOR() { return d_XNOR; }
+  bool                     getCNF() { return d_CNF; }
+  bool                     getRNL() { return d_RNL; }
+  bool                     getNUMOP() { return d_NUM_OP; }
+  uint32_t                 getminLevel() { return d_minLevel; }
+  uint32_t                 getmaxLevel() { return d_maxLevel; }
+  uint32_t                 getminElement() { return d_minElement; }
+  uint32_t                 getmaxElement() { return d_maxElement; }
+  std::map<Gates, int32_t> getm() { return d_m; }
+  bool                     getLeaveEmptyOut() { return d_LeaveEmptyOut; }
+  void                     setALL(bool i_ALL) { d_ALL = i_ALL; }
+  void                     setSUM(bool i_SUM) { d_SUM = i_SUM; }
+  void                     setSUB(bool i_SUB) { d_SUB = i_SUB; }
+  void                     setNSUM(bool i_NSUM) { d_NSUM = i_NSUM; }
+  void                     setNSUB(bool i_NSUB) { d_NSUB = i_NSUB; }
+  void                     setMULT(bool i_MULT) { d_MULT = i_MULT; }
+  void                     setCOM(bool i_COM) { d_COM = i_COM; }
+  void                     setAND(bool i_AND) { d_AND = i_AND; }
+  void                     setNAND(bool i_NAND) { d_NAND = i_NAND; }
+  void                     setOR(bool i_OR) { d_OR = i_OR; }
+  void                     setNOR(bool i_NOR) { d_NOR = i_NOR; }
+  void                     setXOR(bool i_XOR) { d_XOR = i_XOR; }
+  void                     setXNOR(bool i_XNOR) { d_XNOR = i_XNOR; }
+  void                     setCNF(bool i_CNF) { d_CNF = i_CNF; }
+  void                     setRNL(int32_t i_RNL) { d_RNL = i_RNL; }
+  void                     setNUMOP(int32_t i_NUM_OP) { d_NUM_OP = i_NUM_OP; }
+  void setminLevel(uint32_t i_minLevel) { d_minLevel = i_minLevel; }
+  void setmaxLevel(uint32_t i_maxLevel) { d_maxLevel = i_maxLevel; }
+  void setminElement(uint32_t i_minElement) { d_minElement = i_minElement; }
+  void setmaxElement(uint32_t i_maxElement) { d_maxElement = i_maxElement; }
+  void setm(std::map<Gates, int32_t> i_m) { d_m = i_m; }
   void setLeaveEmptyOut(bool i_LeaveEmptyOut) {
     d_LeaveEmptyOut = i_LeaveEmptyOut;
   }
 
 private:
-  bool                 d_ALL    = false;
-  bool                 d_SUM    = false;
-  bool                 d_SUB    = false;
-  bool                 d_NSUM   = false;
-  bool                 d_NSUB   = false;
-  bool                 d_MULT   = false;
-  bool                 d_COM    = false;
-  bool                 d_AND    = false;
-  bool                 d_NAND   = false;
-  bool                 d_OR     = false;
-  bool                 d_NOR    = false;
-  bool                 d_XOR    = false;
-  bool                 d_XNOR   = false;
-  bool                 d_CNF    = false;
-  bool                 d_RNL    = false;
-  bool                 d_NUM_OP = false;
-  int                  d_minLevel;
-  int                  d_maxLevel;
-  int                  d_minElement;
-  int                  d_maxElement;
-  std::map<Gates, int> d_m;
-  bool                 d_LeaveEmptyOut;
+  bool                     d_ALL    = false;
+  bool                     d_SUM    = false;
+  bool                     d_SUB    = false;
+  bool                     d_NSUM   = false;
+  bool                     d_NSUB   = false;
+  bool                     d_MULT   = false;
+  bool                     d_COM    = false;
+  bool                     d_AND    = false;
+  bool                     d_NAND   = false;
+  bool                     d_OR     = false;
+  bool                     d_NOR    = false;
+  bool                     d_XOR    = false;
+  bool                     d_XNOR   = false;
+  bool                     d_CNF    = false;
+  bool                     d_RNL    = false;
+  bool                     d_NUM_OP = false;
+  uint32_t                 d_minLevel;
+  uint32_t                 d_maxLevel;
+  uint32_t                 d_minElement;
+  uint32_t                 d_maxElement;
+  std::map<Gates, int32_t> d_m;
+  bool                     d_LeaveEmptyOut;
 };
 
 /// @todo: To add desc some fields
@@ -303,9 +303,9 @@ public:
   GenerationParameters(
       const std::string& i_name,
       const std::string& i_requestId,
-      int                i_inputs,
-      int                i_outputs,
-      int                i_iteration,
+      uint32_t           i_inputs,
+      uint32_t           i_outputs,
+      uint32_t           i_iteration,
       std::string        i_libraryName        = "",
       bool               i_calculateStatsAbc  = false,
       bool               i_makeOptimizedFiles = false,
@@ -337,30 +337,30 @@ public:
     d_libraryName = i_libraryName;
   }
 
-  int  getInputs() const { return d_inputs; }
+  uint32_t getInputs() const { return d_inputs; }
 
-  void setInputs(int i_inputs) { d_inputs = i_inputs; }
+  void     setInputs(uint32_t i_inputs) { d_inputs = i_inputs; }
 
-  int  getOutputs() const { return d_outputs; }
+  uint32_t getOutputs() const { return d_outputs; }
 
-  void setOutputs(int i_outputs) { d_outputs = i_outputs; }
+  void     setOutputs(uint32_t i_outputs) { d_outputs = i_outputs; }
 
-  int  getIteration() const { return d_iteration; }
+  uint32_t getIteration() const { return d_iteration; }
 
-  void setIteration(int i_iteration) { d_iteration = i_iteration; }
+  void     setIteration(uint32_t i_iteration) { d_iteration = i_iteration; }
 
-  bool getMakeGraphML() const { return d_makeGraphML; }
+  bool     getMakeGraphML() const { return d_makeGraphML; }
 
   std::uint_fast32_t getSeed() const { return d_seed; }
 
   void               setSeed(std::uint_fast32_t i_seed) { d_seed = i_seed; }
 
-  std::map<std::string, std::vector<int>> getGatesInputsInfo() const {
+  std::map<std::string, std::vector<int32_t>> getGatesInputsInfo() const {
     return d_gatesInputsInfo;
   }
 
   void setGatesInputInfo(
-      const std::map<std::string, std::vector<int>>& i_gatesInputsInfo
+      const std::map<std::string, std::vector<int32_t>>& i_gatesInputsInfo
   ) {
     d_gatesInputsInfo = i_gatesInputsInfo;
   }
@@ -394,10 +394,10 @@ public:
     d_cnfFromTruthTableParameters.setLimit(i_limit);
   }
   void setRandLevelParameters(
-      int i_minLevel,
-      int i_maxLevel,
-      int i_minElements,
-      int i_maxElements
+      uint32_t i_minLevel,
+      uint32_t i_maxLevel,
+      uint32_t i_minElements,
+      uint32_t i_maxElements
   ) {
     d_generatorRandLevelParameters.setMinLevel(i_minLevel);
     d_generatorRandLevelParameters.setMaxLevel(i_maxLevel);
@@ -405,8 +405,8 @@ public:
     d_generatorRandLevelParameters.setMaxElements(i_maxElements);
   }
   void setNumOperationParameters(
-      const std::map<Gates, int>& i_m,
-      bool                        i_LeaveEmptyOut
+      const std::map<Gates, int32_t>& i_m,
+      bool                            i_LeaveEmptyOut
   ) {
     d_generatorNumOperationParameters.setLogicOper(i_m);
     d_generatorNumOperationParameters.setLeaveEmptyOut(i_LeaveEmptyOut);
@@ -439,28 +439,28 @@ public:
     d_generatorComparisonParameters.setCompare2(i_compare2);
   }
   void setALUParameters(
-      bool                 i_ALL,
-      bool                 i_SUM,
-      bool                 i_SUB,
-      bool                 i_NSUM,
-      bool                 i_NSUB,
-      bool                 i_MULT,
-      bool                 i_COM,
-      bool                 i_AND,
-      bool                 i_NAND,
-      bool                 i_OR,
-      bool                 i_NOR,
-      bool                 i_XOR,
-      bool                 i_XNOR,
-      bool                 i_CNF,
-      bool                 i_RNL,
-      bool                 i_NUM_OP,
-      int                  i_minLevel,
-      int                  i_maxLevel,
-      int                  i_minElement,
-      int                  i_maxElement,
-      std::map<Gates, int> i_m,
-      bool                 i_LeaveEmptyOut
+      bool                     i_ALL,
+      bool                     i_SUM,
+      bool                     i_SUB,
+      bool                     i_NSUM,
+      bool                     i_NSUB,
+      bool                     i_MULT,
+      bool                     i_COM,
+      bool                     i_AND,
+      bool                     i_NAND,
+      bool                     i_OR,
+      bool                     i_NOR,
+      bool                     i_XOR,
+      bool                     i_XNOR,
+      bool                     i_CNF,
+      bool                     i_RNL,
+      bool                     i_NUM_OP,
+      uint32_t                 i_minLevel,
+      uint32_t                 i_maxLevel,
+      uint32_t                 i_minElement,
+      uint32_t                 i_maxElement,
+      std::map<Gates, int32_t> i_m,
+      bool                     i_LeaveEmptyOut
   ) {
     d_generatorALUParameters.setALL(i_ALL);
     d_generatorALUParameters.setSUM(i_SUM);
@@ -489,19 +489,19 @@ public:
   void setZhegalkin(bool i_zhegalkin) {
     d_ZhegalkinFromTruthTableParameters.setZhegalkin(i_zhegalkin);
   }
-  void setNumOfCycles(int i_numOfCycles) {
+  void setNumOfCycles(uint32_t i_numOfCycles) {
     d_geneticParameters.setNumOfCycles(i_numOfCycles);
   }
-  void setPopulationSize(int i_populationSize) {
+  void setPopulationSize(uint32_t i_populationSize) {
     d_geneticParameters.setPopulationSize(i_populationSize);
   }
   void setRecombinationParameters(
       ParentsTypes       i_parentsTypes,
-      int                i_tournamentNumber,
+      uint32_t           i_tournamentNumber,
       RecombinationTypes i_recombinationType,
-      int                i_refPoints,
+      uint32_t           i_refPoints,
       double             maskProbability,
-      int                i_recombinationNumber
+      uint32_t           i_recombinationNumber
   ) {
     RecombinationParameters RP;
     RP.setParentsParameters(i_parentsTypes, i_tournamentNumber);
@@ -514,7 +514,7 @@ public:
   void setMutationParameters(
       MutationTypes i_mutationType,
       double        i_probabilityGen,
-      int           i_exchangeType,
+      uint32_t      i_exchangeType,
       double        i_probabilityTruthTable
   ) {
     MutationParameters MP;
@@ -526,7 +526,7 @@ public:
   }
   void setSelectionParameters(
       SelectionTypes i_selectionType,
-      int            i_numOfSurvivors
+      uint32_t       i_numOfSurvivors
   ) {
     SelectionParameters SP;
     SP.setSelectionType(i_selectionType);
@@ -538,28 +538,28 @@ public:
   }
 
 private:
-  std::string                             d_name = "";
-  std::string                             d_requestId;
-  std::string                             d_libraryName;
-  int                                     d_inputs    = 0;
-  int                                     d_outputs   = 0;
-  int                                     d_iteration = 0;
-  bool                                    d_calculateStatsAbc;
-  bool                                    d_makeOptimizedFiles;
-  bool                                    d_makeFirrtl;
-  bool                                    d_makeBench;
-  bool                                    d_makeGraphML;
-  std::map<std::string, std::vector<int>> d_gatesInputsInfo;
+  std::string                                 d_name = "";
+  std::string                                 d_requestId;
+  std::string                                 d_libraryName;
+  uint32_t                                    d_inputs    = 0;
+  uint32_t                                    d_outputs   = 0;
+  uint32_t                                    d_iteration = 0;
+  bool                                        d_calculateStatsAbc;
+  bool                                        d_makeOptimizedFiles;
+  bool                                        d_makeFirrtl;
+  bool                                        d_makeBench;
+  bool                                        d_makeGraphML;
+  std::map<std::string, std::vector<int32_t>> d_gatesInputsInfo;
 
-  std::uint_fast32_t                      d_seed = 0;
+  std::uint_fast32_t                          d_seed = 0;
 
-  CNNFromTruthTableParameters             d_cnfFromTruthTableParameters;
-  zhegalkinFromTruthTableParameters       d_ZhegalkinFromTruthTableParameters;
-  GeneratorRandLevelParameters            d_generatorRandLevelParameters;
-  GeneratorNumOperationParameters         d_generatorNumOperationParameters;
-  GeneratorSummatorParameters             d_generatorSummatorParameters;
-  GeneratorComparisonParameters           d_generatorComparisonParameters;
-  GeneratorSubtractorParameters           d_generatorSubtractorParameters;
-  GeneratorALUParameters                  d_generatorALUParameters;
+  CNNFromTruthTableParameters                 d_cnfFromTruthTableParameters;
+  zhegalkinFromTruthTableParameters d_ZhegalkinFromTruthTableParameters;
+  GeneratorRandLevelParameters      d_generatorRandLevelParameters;
+  GeneratorNumOperationParameters   d_generatorNumOperationParameters;
+  GeneratorSummatorParameters       d_generatorSummatorParameters;
+  GeneratorComparisonParameters     d_generatorComparisonParameters;
+  GeneratorSubtractorParameters     d_generatorSubtractorParameters;
+  GeneratorALUParameters            d_generatorALUParameters;
   GeneticParameters d_geneticParameters = GeneticParameters(2, 3);
 };

--- a/src/generators/Genetic/ChronosomeType.h
+++ b/src/generators/Genetic/ChronosomeType.h
@@ -49,7 +49,7 @@ public:
   {
     if constexpr (std::is_same_v<Type, TruthTable>)
     {
-      int numInt = 0;
+      uint32_t numInt = 0;
       for (const auto& nucleosoms : d_chronosome.getOutTable())
         for (const auto& nucleosom : nucleosoms)
           if (nucleosom)

--- a/src/generators/Genetic/GenGenerator.h
+++ b/src/generators/Genetic/GenGenerator.h
@@ -29,16 +29,15 @@ bool isNumber(const std::string& s)
   return true;
 }
 
-int getNumFolderFromString(const std::string& path)
+uint32_t getNumFolderFromString(const std::string& path)
 {
-  int lastSlash = 0;
-  for (int i = 0; i < path.size(); ++i)
+  size_t lastSlash = 0;
+  for (size_t i = 0; i < path.size(); ++i)
   {
     if (path[i] == '_')
       lastSlash = i;
   }
   std::string lastDir = path.substr(lastSlash);
-  int res = 0;
   if (!isNumber(lastDir))
     return 0;
   return std::stoi(lastDir);
@@ -63,7 +62,7 @@ class GeneticGenerator
 public:
   GeneticGenerator(
     const ParametersType& i_parameters,
-    std::pair<int, int> i_inout,
+    std::pair<int32_t, int32_t> i_inout,
     const std::string& i_mainPath) :
     d_parameters(i_parameters),
     d_inputs(i_inout.first),
@@ -100,7 +99,7 @@ public:
   {
     createPopulation();
     double d = endProcessFunction();
-    for (int i = 0; (i < d_parameters.getNumOfCycles()) && (endProcessFunction() < d_parameters.getKeyEndProcessIndex()); ++i)
+    for (int32_t i = 0; (i < d_parameters.getNumOfCycles()) && (endProcessFunction() < d_parameters.getKeyEndProcessIndex()); ++i)
     {
         std::vector<ChronosomeType<Type, ParametersType>> newPopulation = RecombinationType<Type, ParametersType>(d_parameters.getRecombinationParameters(), d_population);
         std::vector<ChronosomeType<Type, ParametersType>> mutants = MutationType<Type, ParametersType>(d_parameters.getMutationParameters(), newPopulation);
@@ -112,14 +111,14 @@ public:
   }
 
 private:
-  int d_inputs;
-  int d_outputs;
-  int d_numCross;
+  uint32_t d_inputs;
+  uint32_t d_outputs;
+  uint32_t d_numCross;
   std::vector<ChronosomeType<Type, ParametersType>> d_population;
   std::shared_ptr<Settings> d_settings = Settings::getInstance("GraphVertex");
   ParametersType d_parameters;
   std::string d_mainPath;
-  int d_foldersCount = 0;
+  uint32_t d_foldersCount = 0;
 
   void savePopulation(
     const std::vector<ChronosomeType<Type, ParametersType>>& i_population
@@ -161,7 +160,7 @@ private:
   void createPopulation()
   {
     d_population.clear();
-    for (int i = 0; i < d_parameters.getPopulationSize(); ++i)
+    for (int32_t i = 0; i < d_parameters.getPopulationSize(); ++i)
     {
         Type gen;
         gen.generateRandom(d_parameters);

--- a/src/generators/Genetic/GeneticParameters.cpp
+++ b/src/generators/Genetic/GeneticParameters.cpp
@@ -1,35 +1,35 @@
 #include <tuple>
-
+#include <cstdint>
 #include "GeneticParameters.h"
 
 void GeneticParameters::setKeyEndProcessIndex(double i_keyEndProcessIndex) {
   d_keyEndProcessIndex = i_keyEndProcessIndex;
 }
 
-void GeneticParameters::setPopulationSize(int i_populationSize) {
+void GeneticParameters::setPopulationSize(uint32_t i_populationSize) {
   d_populationSize = i_populationSize;
 }
 
-void GeneticParameters::setNumOfCycles(int i_numOfCycles) {
+void GeneticParameters::setNumOfCycles(uint32_t i_numOfCycles) {
   d_numOfCycles = i_numOfCycles;
 }
 
-GeneticParameters::GeneticParameters(int i_inputs, int i_outputs) :
+GeneticParameters::GeneticParameters(uint32_t i_inputs, uint32_t i_outputs) :
   d_inputs(i_inputs), d_outputs(i_outputs) {};
 
-int GeneticParameters::getInputs() const {
+uint32_t GeneticParameters::getInputs() const {
   return d_inputs;
 }
 
-void GeneticParameters::setInputs(int i_inputs) {
+void GeneticParameters::setInputs(uint32_t i_inputs) {
   d_inputs = i_inputs;
 }
 
-int GeneticParameters::getOutputs() const {
+uint32_t GeneticParameters::getOutputs() const {
   return d_outputs;
 }
 
-void GeneticParameters::setOutputs(int i_outputs) {
+void GeneticParameters::setOutputs(uint32_t i_outputs) {
   d_outputs = i_outputs;
 }
 
@@ -60,11 +60,11 @@ void GeneticParameters::setMutationParameters(const MutationParameters& i_mp) {
   d_mutationParameters = i_mp;
 }
 
-int OrientedGraphParameters::getMaxLevel() const {
+uint32_t OrientedGraphParameters::getMaxLevel() const {
   return d_maxLevel;
 }
 
-int OrientedGraphParameters::getMaxElements() const {
+uint32_t OrientedGraphParameters::getMaxElements() const {
   return d_maxElements;
 }
 
@@ -72,13 +72,16 @@ bool OrientedGraphParameters::empty() const {
   return d_maxLevel == 0 && d_maxElements == 0;
 }
 
-TruthTableParameters::TruthTableParameters(int i_inputs, int i_outputs) :
+TruthTableParameters::TruthTableParameters(
+    uint32_t i_inputs,
+    uint32_t i_outputs
+) :
   GeneticParameters(i_inputs, i_outputs) {}
 
 TruthTableParameters::TruthTableParameters(const GeneticParameters& i_gp) :
   GeneticParameters(i_gp) {}
 
-int TruthTableParameters::size() const {
+uint32_t TruthTableParameters::size() const {
   return 1u << d_inputs;
 }
 

--- a/src/generators/Genetic/GeneticParameters.cpp
+++ b/src/generators/Genetic/GeneticParameters.cpp
@@ -1,5 +1,6 @@
-#include <tuple>
 #include <cstdint>
+#include <tuple>
+
 #include "GeneticParameters.h"
 
 void GeneticParameters::setKeyEndProcessIndex(double i_keyEndProcessIndex) {

--- a/src/generators/Genetic/GeneticParameters.h
+++ b/src/generators/Genetic/GeneticParameters.h
@@ -25,35 +25,35 @@ public:
   /// @param i_inputs Number of inputs
   /// @param outs Number of outputs
 
-  GeneticParameters(int i_inputs = 0, int outs = 0);
+  GeneticParameters(uint32_t i_inputs = 0, uint32_t outs = 0);
 
 
   /// @brief getInputs
   /// Get the number of inputs
   /// @return The number of inputs
 
-  int getInputs() const;
+  uint32_t getInputs() const;
 
 
   /// @brief setInputs
   /// Set the number of inputs
   /// @param i_inputs The number of inputs
 
-  void setInputs(int i_inputs);
+  void setInputs(uint32_t i_inputs);
 
 
   /// @brief getOutputs
   /// Get the number of outputs
   /// @return The number of outputs
 
-  int getOutputs() const;
+  uint32_t getOutputs() const;
 
 
   /// @brief setOutputs
   /// Set the number of outputs
   /// @param i_outputs The number of outputs
 
-  void setOutputs(int i_outputs);
+  void setOutputs(uint32_t i_outputs);
 
 
   SelectionParameters getSelectionParameters() const;
@@ -62,18 +62,18 @@ public:
   void setRecombinationParameters(const RecombinationParameters& i_rp);
   MutationParameters getMutationParameters() const;
   void setMutationParameters(const MutationParameters& i_mp);
-  void setPopulationSize(int i_populationSize);
-  void setNumOfCycles(int i_numOfCycles);
+  void setPopulationSize(uint32_t i_populationSize);
+  void setNumOfCycles(uint32_t i_numOfCycles);
   void setKeyEndProcessIndex(double i_keyEndProcessIndex);
   double getKeyEndProcessIndex() { return d_keyEndProcessIndex; }
-  int getNumOfCycles() { return d_numOfCycles; }
+  uint32_t getNumOfCycles() { return d_numOfCycles; }
 
  
 protected:
-  int d_inputs;
-  int d_outputs;
-  int d_populationSize = 0;
-  int d_numOfCycles = 0;
+  uint32_t d_inputs;
+  uint32_t d_outputs;
+  uint32_t d_populationSize = 0;
+  uint32_t d_numOfCycles = 0;
   SelectionParameters d_selectionParameters;
   RecombinationParameters d_recombinationParameters;
   MutationParameters d_mutationParameters;
@@ -84,13 +84,13 @@ protected:
 class OrientedGraphParameters : public GeneticParameters
 {
 public:
-  int getMaxLevel() const;
-  int getMaxElements() const;
+  uint32_t getMaxLevel() const;
+  uint32_t getMaxElements() const;
   bool empty() const;
 
 private:
-  int d_maxLevel = 0;
-  int d_maxElements = 0;
+  uint32_t d_maxLevel = 0;
+  uint32_t d_maxElements = 0;
 };
 
 
@@ -109,7 +109,7 @@ public:
   /// @brief TruthTableParameters
   /// @param i_inputs Number of truth table inputs
   /// @param i_outputs Number of truth table outputs
-  TruthTableParameters(int i_inputs = 0, int i_outputs = 0);
+  TruthTableParameters(uint32_t i_inputs = 0, uint32_t i_outputs = 0);
 
   /// @brief TruthTableParameters
   /// @param i_gp Genetic parameters used to generate the truth table
@@ -119,13 +119,13 @@ public:
   /// @brief getPopulationSize
   /// @todo: Why is this method needed if there is a size
   /// @return truth table population size
-  int getPopulationSize() { return size(); }
+  uint32_t getPopulationSize() { return size(); }
 
   /// @brief size
   /// Returns the size of the truth table population
   /// @return truth table population size
 
-  int size() const;
+  uint32_t size() const;
 
 
   /// @brief Overloaded comparison operator for Truth Table Parameters

--- a/src/generators/Genetic/Mutations/MutationParameters.cpp
+++ b/src/generators/Genetic/Mutations/MutationParameters.cpp
@@ -10,7 +10,7 @@ void MutationParameters::setProbabilityGen(double i_probabilityGen) {
   d_probabilityGen = i_probabilityGen;
 }
 
-void MutationParameters::setExchangeType(int i_exchangeType) {
+void MutationParameters::setExchangeType(int32_t i_exchangeType) {
   d_exchangeType = i_exchangeType;
 }
 
@@ -27,7 +27,7 @@ double MutationParameters::getProbabilityGen() const {
   return d_probabilityGen;
 }
 
-int MutationParameters::getExchangeType() const {
+int32_t MutationParameters::getExchangeType() const {
   return d_exchangeType;
 }
 

--- a/src/generators/Genetic/Mutations/MutationParameters.h
+++ b/src/generators/Genetic/Mutations/MutationParameters.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 enum MutationTypes
 {
@@ -16,16 +17,16 @@ public:
   MutationParameters() = default;
   MutationTypes getMutationType() const;
   double getProbabilityGen() const;
-  int getExchangeType() const;
+  int32_t getExchangeType() const;
   double getProbabilityTruthTable() const;
   bool operator== (const MutationParameters& r) const;
   void setMutationType(MutationTypes i_mutationType);
   void setProbabilityGen(double i_probabilityGen);
-  void setExchangeType(int i_exchangeType);
+  void setExchangeType(int32_t i_exchangeType);
   void setProbabilityTruthTable(double i_probabilityTruthTable);
 private:
   MutationTypes d_mutationType = MutationTypes::Binary;
   double d_probabilityGen = 0.1;
-  int d_exchangeType = 0;
+  int32_t d_exchangeType = 0;
   double d_probabilityTruthTable = 0.1;
 };

--- a/src/generators/Genetic/Mutations/MutationTruthTable.cpp
+++ b/src/generators/Genetic/Mutations/MutationTruthTable.cpp
@@ -14,8 +14,8 @@ std::vector<std::vector<bool>> MutationTable(
   std::srand(std::time(0));
   std::default_random_engine             generator;
   std::uniform_real_distribution<double> distribution(0.0, 1.0);
-  for (int i = 0; i < i_table.size(); ++i) {
-    for (int j = 0; j < i_table[i].size(); ++j) {
+  for (size_t i = 0; i < i_table.size(); ++i) {
+    for (size_t j = 0; j < i_table[i].size(); ++j) {
       if (distribution(generator) < i_probability) {
         i_table[i][j] = !i_table[i][j];
       }
@@ -29,16 +29,16 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>> MutationBinary(
     std::vector<ChronosomeType<TruthTable, TruthTableParameters>> i_population
 ) {
   std::vector<ChronosomeType<TruthTable, TruthTableParameters>> mutants;
-  int                                                           num_mut, k, n;
-  int size   = i_population[0].getChronosomeType().size();
-  int output = i_population[0].getChronosomeType().getOutput();
+  int32_t                                                       num_mut, k, n;
+  size_t  size   = i_population[0].getChronosomeType().size();
+  int32_t output = i_population[0].getChronosomeType().getOutput();
   std::srand(time(0));
-  for (int i = 0; i < i_population.size(); ++i) {
+  for (size_t i = 0; i < i_population.size(); ++i) {
     num_mut = (rand() % (size * output)) + 1;
     std::vector<std::vector<bool>> mutant =
         i_population[i].getChronosomeType().getOutTable();
-    std::vector<int> m;
-    for (int j = 0; j < num_mut; ++j) {
+    std::vector<int32_t> m;
+    for (int32_t j = 0; j < num_mut; ++j) {
       do {
         n = rand() % output;
         k = rand() % size;
@@ -68,7 +68,7 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>> MutationDensity(
       {}};
   // std::vector<bool> bin = tt.getOutTable();
 
-  for (int i = 0; i < i_population.size(); ++i) {
+  for (size_t i = 0; i < i_population.size(); ++i) {
     if (distribution(generator) < i_mutationParameters.getProbabilityGen()) {
       std::vector<std::vector<bool>> mutant = MutationTable(
           i_population[i].getChronosomeType().getOutTable(),
@@ -91,7 +91,7 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>>
   std::srand(std::time(0));
   std::default_random_engine             generator;
   std::uniform_real_distribution<double> distribution(0.0, 1.0);
-  int        size = i_population[0].getChronosomeType().size();
+  int64_t    size = i_population[0].getChronosomeType().size();
 
   TruthTable tt   = {
       i_population[0].getChronosomeType().getInput(),
@@ -99,7 +99,7 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>>
       {}};
   std::vector<std::vector<bool>> bin = tt.getOutTable();
 
-  for (int i = 0; i < i_population.size(); ++i) {
+  for (size_t i = 0; i < i_population.size(); ++i) {
     if (distribution(generator) < i_mutationParameters.getProbabilityGen()) {
       std::vector<std::vector<bool>> bin2 =
           i_population[i].getChronosomeType().getOutTable();
@@ -120,12 +120,12 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>> MutationInsertDel(
   std::default_random_engine             generator;
   std::uniform_real_distribution<double> distribution(0.0, 1.0);
 
-  int        size = i_population[0].getChronosomeType().size();
+  int64_t    size = i_population[0].getChronosomeType().size();
 
   TruthTable tt   = {i_population[0].getChronosomeType()};
   std::vector<std::vector<bool>> bin = tt.getOutTable();
 
-  for (int i = 0; i < i_population.size(); ++i) {
+  for (size_t i = 0; i < i_population.size(); ++i) {
     if (distribution(generator) < i_mutationParameters.getProbabilityGen()) {
       std::vector<std::vector<bool>> bin2 =
           i_population[i].getChronosomeType().getOutTable();
@@ -146,14 +146,14 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>> MutationExchange(
   std::default_random_engine             generator;
   std::uniform_real_distribution<double> distribution(0.0, 1.0);
 
-  int type   = i_mutationParameters.getExchangeType();
-  int size   = i_population[0].getChronosomeType().size();
-  int output = i_population[0].getChronosomeType().getOutput();
+  int32_t type   = i_mutationParameters.getExchangeType();
+  int32_t size   = i_population[0].getChronosomeType().size();
+  int32_t output = i_population[0].getChronosomeType().getOutput();
 
-  int k      = rand() % size;
-  int n      = rand() % output;
+  int32_t k      = rand() % size;
+  int32_t n      = rand() % output;
 
-  for (int z = 0; z < i_population.size(); ++z) {
+  for (size_t z = 0; z < i_population.size(); ++z) {
     if (distribution(generator) < i_mutationParameters.getProbabilityGen()) {
       if (type == 0 || type == 1 || type == 2) {
         if (type == 0 || type == 1) {
@@ -191,13 +191,13 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>> MutationDelete(
   std::default_random_engine             generator;
   std::uniform_real_distribution<double> distribution(0.0, 1.0);
 
-  int size   = i_population[0].getChronosomeType().size();
-  int output = i_population[0].getChronosomeType().getOutput();
+  int32_t size   = i_population[0].getChronosomeType().size();
+  int32_t output = i_population[0].getChronosomeType().getOutput();
 
-  for (int i = 0; i < i_population.size(); ++i) {
+  for (size_t i = 0; i < i_population.size(); ++i) {
     if (distribution(generator) < i_mutationParameters.getProbabilityGen()) {
-      for (int j = 0; j < size; ++j) {
-        for (int k = 0; k < output; ++k) {
+      for (int32_t j = 0; j < size; ++j) {
+        for (int32_t k = 0; k < output; ++k) {
           if (distribution(generator)
               < i_mutationParameters.getProbabilityTruthTable()) {
             std::vector<std::vector<bool>> bin =

--- a/src/generators/Genetic/Parents/Parents.h
+++ b/src/generators/Genetic/Parents/Parents.h
@@ -12,11 +12,11 @@
 
 
 template<typename Type, typename ParametersType>
-std::vector<int> ParentsTypesWorker(ParentsParameters i_parentsParameters,
+std::vector<int32_t> ParentsTypesWorker(ParentsParameters i_parentsParameters,
                               std::vector<ChronosomeType<Type, ParametersType>> i_population
 );
 template<>
-inline std::vector<int> ParentsTypesWorker(ParentsParameters i_parentsParameters,
+inline std::vector<int32_t> ParentsTypesWorker(ParentsParameters i_parentsParameters,
                               std::vector<ChronosomeType<TruthTable, TruthTableParameters>> i_population
 )
 {

--- a/src/generators/Genetic/Parents/ParentsParameters.cpp
+++ b/src/generators/Genetic/Parents/ParentsParameters.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <tuple>
 
 #include "ParentsParameters.h"
@@ -10,11 +11,11 @@ ParentsTypes ParentsParameters::getParentsType() const {
   return d_parentsType;
 }
 
-void ParentsParameters::setTournamentNumber(int i_tournamentNumber) {
+void ParentsParameters::setTournamentNumber(int32_t i_tournamentNumber) {
   d_tournamentNumber = i_tournamentNumber;
 }
 
-int ParentsParameters::getTournamentNumber() const {
+int32_t ParentsParameters::getTournamentNumber() const {
   return d_tournamentNumber;
 }
 

--- a/src/generators/Genetic/Parents/ParentsParameters.h
+++ b/src/generators/Genetic/Parents/ParentsParameters.h
@@ -12,11 +12,11 @@ class ParentsParameters {
 public:
   void setParentsType(ParentsTypes i_parentsTypes);
   ParentsTypes getParentsType() const;
-  void setTournamentNumber(int i_tournamentNumber);
-  int getTournamentNumber() const;
+  void setTournamentNumber(int32_t i_tournamentNumber);
+  int32_t getTournamentNumber() const;
   bool operator== (const ParentsParameters& r) const;
 
 private:
-  int d_tournamentNumber = 2;
+  int32_t d_tournamentNumber = 2;
   ParentsTypes d_parentsType = ParentsTypes::Panmixia;
 };

--- a/src/generators/Genetic/Parents/ParentsTruthTable.hpp
+++ b/src/generators/Genetic/Parents/ParentsTruthTable.hpp
@@ -10,23 +10,23 @@
 
 #include "../ChronosomeType.h"
 
-inline std::vector<int> GetHemming(
-    int                                                           i_t,
+inline std::vector<int32_t> GetHemming(
+    int32_t                                                       i_t,
     std::vector<ChronosomeType<TruthTable, TruthTableParameters>> i_population
 ) {
-  int                            count = 0;
+  int32_t                        count = 0;
   std::vector<std::vector<bool>> p1 =
       i_population[i_t].getChronosomeType().getOutTable();
-  std::map<int, int> dict;
-  std::vector<int>   res;
+  std::map<int32_t, int32_t> dict;
+  std::vector<int32_t>       res;
 
-  for (int i = 0; i < i_population.size(); ++i) {
+  for (size_t i = 0; i < i_population.size(); ++i) {
     if (i != i_t) {
       count = 0;
       std::vector<std::vector<bool>> p2 =
           i_population[i].getChronosomeType().getOutTable();
-      for (int j = 0; j < p1.size(); ++j) {
-        for (int k = 0; k < p1[0].size(); ++k) {
+      for (size_t j = 0; j < p1.size(); ++j) {
+        for (size_t k = 0; k < p1[0].size(); ++k) {
           if (p2[j][k] == p1[j][k])  // what? is it Hemming dist?
             ++count;
         }
@@ -43,12 +43,12 @@ inline std::vector<int> GetHemming(
   return res;
 };
 
-inline std::vector<int> ParentsPanmixia(
+inline std::vector<int32_t> ParentsPanmixia(
     ParentsParameters i_parentsParameters,
     std::vector<ChronosomeType<TruthTable, TruthTableParameters>> i_population
 ) {
   std::srand(std::time(0));
-  int parent1 = 0, parent2 = 0;
+  int32_t parent1 = 0, parent2 = 0;
 
   while (i_population.size() > 2 && parent1 == parent2) {
     parent1 = rand() % i_population.size();
@@ -58,44 +58,44 @@ inline std::vector<int> ParentsPanmixia(
   return {parent1, parent2};
 }
 
-inline std::vector<int> ParentsInbrinding(
+inline std::vector<int32_t> ParentsInbrinding(
     ParentsParameters i_parentsParameters,
     std::vector<ChronosomeType<TruthTable, TruthTableParameters>> i_population
 ) {
   std::srand(std::time(0));
 
-  int parent1 = rand() % i_population.size();
-  int parent2 = GetHemming(parent1, i_population).back();
+  int32_t parent1 = rand() % i_population.size();
+  int32_t parent2 = GetHemming(parent1, i_population).back();
 
   return {parent1, parent2};
 }
 
-inline std::vector<int> ParentsOutbrinding(
+inline std::vector<int32_t> ParentsOutbrinding(
     ParentsParameters i_parentsParameters,
     std::vector<ChronosomeType<TruthTable, TruthTableParameters>> i_population
 ) {
   std::srand(std::time(0));
 
-  int parent1 = rand() % i_population.size();
-  int parent2 = GetHemming(parent1, i_population).front();
+  int32_t parent1 = rand() % i_population.size();
+  int32_t parent2 = GetHemming(parent1, i_population).front();
 
   return {parent1, parent2};
 }
 
-inline std::vector<int> ParentsTournament(
+inline std::vector<int32_t> ParentsTournament(
     ParentsParameters i_parentsParameters,
     std::vector<ChronosomeType<TruthTable, TruthTableParameters>> i_population
 ) {
-  std::vector<int> beforeAdaptation = AuxMethods::getRandomIntList(
+  std::vector<int32_t> beforeAdaptation = AuxMethods::getRandomIntList(
       i_parentsParameters.getTournamentNumber(), 0, i_population.size(), false
   );
 
-  std::map<int, double> adaptationIndex;
+  std::map<int32_t, double> adaptationIndex;
 
   for (const auto& k : beforeAdaptation)
     adaptationIndex[k] = i_population[k].getAdaptationIndex();
 
-  std::vector<int> res;
+  std::vector<int32_t> res;
 
   for (const auto& [key, value] :
        AuxMethods::sortDictByValue(adaptationIndex, false))
@@ -106,7 +106,7 @@ inline std::vector<int> ParentsTournament(
 }
 
 // TODO: is this ParentTournament???
-inline std::vector<int> ParentsRoulette(
+inline std::vector<int32_t> ParentsRoulette(
     ParentsParameters i_parentsParameters,
     std::vector<ChronosomeType<TruthTable, TruthTableParameters>> i_population
 ) {

--- a/src/generators/Genetic/Parser.cpp
+++ b/src/generators/Genetic/Parser.cpp
@@ -37,16 +37,15 @@ OrientedGraph Parser::getGraph() const {
   return d_graph;
 }
 
-std::pair<bool, std::vector<std::pair<int, int>>> Parser::createBrackets(
-    const std::string& i_expr
-) {
-  std::vector<std::pair<int, int>> brackets;
-  for (int i = 0; i < i_expr.length(); ++i) {
+std::pair<bool, std::vector<std::pair<int32_t, int32_t>>>
+    Parser::createBrackets(const std::string& i_expr) {
+  std::vector<std::pair<int32_t, int32_t>> brackets;
+  for (int32_t i = 0; i < i_expr.length(); ++i) {
     if (i_expr[i] == '(') {
       brackets.push_back({i, -1});
     }
     if (i_expr[i] == ')') {
-      int j = static_cast<int>(brackets.size()) - 1;
+      int32_t j = static_cast<int32_t>(brackets.size()) - 1;
       while (j >= 0 && brackets[j].second != -1)
         --j;
 
@@ -57,7 +56,7 @@ std::pair<bool, std::vector<std::pair<int, int>>> Parser::createBrackets(
     }
   }
 
-  int u = static_cast<int>(brackets.size()) - 1;
+  int32_t u = static_cast<int32_t>(brackets.size()) - 1;
   // assert(u >= 0);
   while (u >= 0 && brackets[u].second != -1)
     --u;
@@ -69,10 +68,10 @@ std::pair<bool, std::vector<std::pair<int, int>>> Parser::createBrackets(
 }
 
 bool Parser::inBrackets(
-    const std::vector<std::pair<int, int>>& i_brackets,
-    int                                     i_position
+    const std::vector<std::pair<int32_t, int32_t>>& i_brackets,
+    int32_t                                         i_position
 ) const {
-  int i = static_cast<int>(i_brackets.size()) - 1;
+  int32_t i = static_cast<int32_t>(i_brackets.size()) - 1;
 
   while (i >= 0
          && !(
@@ -87,8 +86,8 @@ bool Parser::inBrackets(
 }
 
 std::string deleteExtraSpace(const std::string& i_s) {
-  int l = i_s.size(), r = static_cast<int>(i_s.size()) - 1;
-  for (int i = 0; i < i_s.size(); ++i) {
+  int32_t l = i_s.size(), r = static_cast<int32_t>(i_s.size()) - 1;
+  for (int32_t i = 0; i < i_s.size(); ++i) {
     if (i_s[i] != ' ') {
       l = std::min(l, i);
       r = i;
@@ -97,11 +96,11 @@ std::string deleteExtraSpace(const std::string& i_s) {
   return i_s.substr(l, r - l + 1);
 }
 
-std::pair<int, std::vector<std::string>> Parser::splitLogicExpression(
+std::pair<int32_t, std::vector<std::string>> Parser::splitLogicExpression(
     std::string i_expr
 ) {
-  bool f = true;
-  int  l = 0;
+  bool    f = true;
+  int32_t l = 0;
 
   while (f && l <= d_settings->getLogicOperation("input").second) {
     std::vector<std::string> operations =
@@ -110,9 +109,9 @@ std::pair<int, std::vector<std::string>> Parser::splitLogicExpression(
       i_expr = i_expr;  // what?
 
     for (const auto& op : operations) {
-      int index = i_expr.find(op);
+      int32_t index = i_expr.find(op);
       while (index != i_expr.length() && index != std::string::npos) {
-        std::pair<bool, std::vector<std::pair<int, int>>> brackets =
+        std::pair<bool, std::vector<std::pair<int32_t, int32_t>>> brackets =
             createBrackets(i_expr);
         if (!inBrackets(brackets.second, index)) {
           std::vector<std::string> lst;
@@ -145,17 +144,18 @@ std::pair<int, std::vector<std::string>> Parser::splitLogicExpression(
 
 bool Parser::parse(const std::string& i_expr)  // what? change true/false
 {
-  std::pair<int, std::vector<std::string>> t = splitLogicExpression(i_expr);
+  std::pair<int32_t, std::vector<std::string>> t = splitLogicExpression(i_expr);
   if (t.first == -1)
     return false;
 
   if (t.second[0] == "output") {
-    std::vector<std::pair<int, int>> bl = createBrackets(t.second[2]).second;
+    std::vector<std::pair<int32_t, int32_t>> bl =
+        createBrackets(t.second[2]).second;
     for (auto tl : bl)
       if (tl.first == 0 && tl.second == t.second[2].size() - 1)
         t.second[2] = t.second[2].substr(1, t.second[2].size() - 2);
 
-    std::pair<int, std::vector<std::string>> tt =
+    std::pair<int32_t, std::vector<std::string>> tt =
         splitLogicExpression(t.second[2]);
     if (tt.first == -1)
       return false;
@@ -168,16 +168,17 @@ bool Parser::parse(const std::string& i_expr)  // what? change true/false
       parse(t.second[2]);
   } else {
     d_graph.addVertex(i_expr, t.second[0]);
-    for (int i = 1; i < t.second.size(); ++i) {
-      std::string                      part = t.second[i];
+    for (int32_t i = 1; i < t.second.size(); ++i) {
+      std::string                              part = t.second[i];
 
-      std::vector<std::pair<int, int>> bl   = createBrackets(part).second;
+      std::vector<std::pair<int32_t, int32_t>> bl = createBrackets(part).second;
 
       for (auto tl : bl)
-        if (tl.first == 0 && tl.second == static_cast<int>(part.size()) - 1)
-          part = part.substr(1, static_cast<int>(part.size()) - 2);
+        if (tl.first == 0 && tl.second == static_cast<int32_t>(part.size()) - 1)
+          part = part.substr(1, static_cast<int32_t>(part.size()) - 2);
 
-      std::pair<int, std::vector<std::string>> tt = splitLogicExpression(part);
+      std::pair<int32_t, std::vector<std::string>> tt =
+          splitLogicExpression(part);
       if (tt.first == -1)
         return false;
 
@@ -192,7 +193,7 @@ bool Parser::parse(const std::string& i_expr)  // what? change true/false
 
 bool Parser::parseAll() {
   d_graph = OrientedGraph();
-  for (int i = 0; i < d_logExpressions.size(); ++i)
+  for (int32_t i = 0; i < d_logExpressions.size(); ++i)
     if (createBrackets(d_logExpressions[i]).first)
       if (!parse(d_logExpressions[i]))
         return false;
@@ -200,7 +201,7 @@ bool Parser::parseAll() {
 }
 
 std::string Parser::deleteExtraSpaces(std::string i_s) {
-  int i = 0;
+  int32_t i = 0;
   while (i_s[i] == ' ')
     ++i;
   i_s.erase(0, i);

--- a/src/generators/Genetic/Parser.h
+++ b/src/generators/Genetic/Parser.h
@@ -10,7 +10,7 @@ public:
   Parser(const std::string& i_logExpression);
   Parser(const std::vector<std::string>& i_logExpressions);
   OrientedGraph getGraph() const;
-  std::pair<int, std::vector<std::string>> splitLogicExpression(std::string i_expr);
+  std::pair<int32_t, std::vector<std::string>> splitLogicExpression(std::string i_expr);
   bool parse(const std::string& i_expr);
   bool parseAll();
 
@@ -21,7 +21,7 @@ private:
   OrientedGraph d_graph;
   Settings* d_settings = Settings::getInstance("Parser");
 
-  std::pair<bool, std::vector<std::pair<int, int>>> createBrackets(const std::string& i_expr);
-  bool inBrackets(const std::vector<std::pair<int, int>>& i_brackets, int i_position) const;
+  std::pair<bool, std::vector<std::pair<int32_t, int32_t>>> createBrackets(const std::string& i_expr);
+  bool inBrackets(const std::vector<std::pair<int32_t, int32_t>>& i_brackets, int32_t i_position) const;
   std::string deleteExtraSpaces(std::string i_s);
 };

--- a/src/generators/Genetic/Recombination/RecombinationParameters.cpp
+++ b/src/generators/Genetic/Recombination/RecombinationParameters.cpp
@@ -8,7 +8,7 @@ void RecombinationParameters::setMaskProbability(double i_maskProbability) {
 
 void RecombinationParameters::setParentsParameters(
     ParentsTypes i_parentsType,
-    int          i_tournamentSize
+    int32_t      i_tournamentSize
 ) {
   d_parentsParameters.setParentsType(i_parentsType);
   d_parentsParameters.setTournamentNumber(i_tournamentSize);
@@ -28,11 +28,11 @@ ParentsParameters RecombinationParameters::getParentsParameters() const {
   return d_parentsParameters;
 }
 
-int RecombinationParameters::getRefPoints() const {
+int32_t RecombinationParameters::getRefPoints() const {
   return d_refPoints;
 }
 
-void RecombinationParameters::setRefPoints(int i_refPoints) {
+void RecombinationParameters::setRefPoints(int32_t i_refPoints) {
   d_refPoints = i_refPoints;
 }
 
@@ -40,11 +40,11 @@ double RecombinationParameters::getMaskProbability() const {
   return d_maskProbability;
 }
 
-void RecombinationParameters::setRecombinationParameters(int i_rp) {
+void RecombinationParameters::setRecombinationParameters(int32_t i_rp) {
   d_recombinationNumber = i_rp;
 }
 
-int RecombinationParameters::getRecombinationParameters() const {
+int32_t RecombinationParameters::getRecombinationParameters() const {
   return d_recombinationNumber;
 }
 

--- a/src/generators/Genetic/Recombination/RecombinationParameters.h
+++ b/src/generators/Genetic/Recombination/RecombinationParameters.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <cstdint>
 #include "../Parents/ParentsParameters.h"
 
 enum RecombinationTypes
@@ -16,19 +16,19 @@ class RecombinationParameters
 public:
   RecombinationTypes getRecombinationType() const;
   ParentsParameters getParentsParameters() const;
-  int getRefPoints() const;
-  void setRefPoints(int i_refPoints);
+  int32_t getRefPoints() const;
+  void setRefPoints(int32_t i_refPoints);
   double getMaskProbability() const;
-  void setRecombinationParameters(int i_rp);
-  int getRecombinationParameters() const;
+  void setRecombinationParameters(int32_t i_rp);
+  int32_t getRecombinationParameters() const;
   bool operator== (const RecombinationParameters& r) const;
   void setMaskProbability(double i_maskProbability);
-  void setParentsParameters(ParentsTypes i_parentsType, const int i_tournamentSize);
+  void setParentsParameters(ParentsTypes i_parentsType, const int32_t i_tournamentSize);
   void setRecombinationType(RecombinationTypes i_recombinationType);
 private:
   RecombinationTypes d_recombinationType = RecombinationTypes::CrossingEachExitInTurnMany;
   ParentsParameters d_parentsParameters = ParentsParameters();
-  int d_refPoints = 1;
+  int32_t d_refPoints = 1;
   double d_maskProbability = 0.5;
-  int d_recombinationNumber = 1;
+  int32_t d_recombinationNumber = 1;
 };

--- a/src/generators/Genetic/Recombination/RecombinationsTruthTable.cpp
+++ b/src/generators/Genetic/Recombination/RecombinationsTruthTable.cpp
@@ -13,21 +13,22 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>>
             i_population
     ) {
   // TODO: is it need? Parents<TruthTable, TruthTableParameters> p;
-  int              input     = i_population[0].getChronosomeType().getInput();
-  int              output    = i_population[0].getChronosomeType().getOutput();
-  int              size      = i_population[0].getChronosomeType().size();
-  int              refPoints = i_recombinationParameters.getRefPoints();
+  int32_t              input  = i_population[0].getChronosomeType().getInput();
+  int32_t              output = i_population[0].getChronosomeType().getOutput();
+  int32_t              size   = i_population[0].getChronosomeType().size();
+  int32_t              refPoints = i_recombinationParameters.getRefPoints();
 
-  std::vector<int> referencePoints;
+  std::vector<int32_t> referencePoints;
   std::vector<ChronosomeType<TruthTable, TruthTableParameters>> survivors;
 
-  for (int cr = 0; cr < i_recombinationParameters.getRecombinationParameters();
+  for (int32_t cr = 0;
+       cr < i_recombinationParameters.getRecombinationParameters();
        ++cr) {
-    std::vector<int> parentsInt = ParentsTypesWorker(
+    std::vector<int32_t> parentsInt = ParentsTypesWorker(
         i_recombinationParameters.getParentsParameters(), i_population
     );
-    int child1      = parentsInt[0];
-    int child2      = parentsInt[1];
+    int32_t child1  = parentsInt[0];
+    int32_t child2  = parentsInt[1];
 
     referencePoints = AuxMethods::getRandomIntList(refPoints, 0, size, false);
 
@@ -35,9 +36,9 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>>
     parents.push_back(i_population[child1].getChronosomeType().getOutTable());
     parents.push_back(i_population[child2].getChronosomeType().getOutTable());
     std::vector<std::vector<bool>> child(size, std::vector<bool>());
-    int                            stage = 0;
+    int32_t                        stage = 0;
 
-    for (int j = 0; j < size; ++j) {
+    for (int32_t j = 0; j < size; ++j) {
       if (stage < referencePoints.size() && j == referencePoints[stage])
         stage++;
       child[j] = parents[stage % parents.size()][j];
@@ -59,19 +60,20 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>>
             i_population
     ) {
   // Parents<TruthTable, TruthTableParameters> p;
-  int input  = i_population[0].getChronosomeType().getInput();
-  int output = i_population[0].getChronosomeType().getOutput();
-  int size   = i_population[0].getChronosomeType().size();
+  int32_t input  = i_population[0].getChronosomeType().getInput();
+  int32_t output = i_population[0].getChronosomeType().getOutput();
+  int32_t size   = i_population[0].getChronosomeType().size();
 
   std::vector<ChronosomeType<TruthTable, TruthTableParameters>> survivors;
 
-  for (int cr = 0; cr < i_recombinationParameters.getRecombinationParameters();
+  for (int32_t cr = 0;
+       cr < i_recombinationParameters.getRecombinationParameters();
        ++cr) {
-    std::vector<int> parentsInt = ParentsTypesWorker(
+    std::vector<int32_t> parentsInt = ParentsTypesWorker(
         i_recombinationParameters.getParentsParameters(), i_population
     );
-    int        child1 = parentsInt[0];
-    int        child2 = parentsInt[1];
+    int32_t    child1 = parentsInt[0];
+    int32_t    child2 = parentsInt[1];
 
     TruthTable mask(
         input, output, i_recombinationParameters.getMaskProbability()
@@ -82,8 +84,8 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>>
     parents.push_back(i_population[child2].getChronosomeType().getOutTable());
     std::vector<std::vector<bool>> child(size, std::vector<bool>(output));
 
-    for (int i = 0; i < size; ++i) {
-      for (int j = 0; j < output; ++j) {
+    for (int32_t i = 0; i < size; ++i) {
+      for (int32_t j = 0; j < output; ++j) {
         child[i][j] = parents[mask.getOutTable(i, j) ? 1 : 0][i][j];
       }
     }
@@ -103,21 +105,22 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>>
         std::vector<ChronosomeType<TruthTable, TruthTableParameters>>
             i_population
     ) {
-  int input  = i_population[0].getChronosomeType().getInput();
-  int output = i_population[0].getChronosomeType().getOutput();
-  int size   = i_population[0].getChronosomeType().size();
+  int32_t input  = i_population[0].getChronosomeType().getInput();
+  int32_t output = i_population[0].getChronosomeType().getOutput();
+  int32_t size   = i_population[0].getChronosomeType().size();
 
-  int child3;
+  int32_t child3;
   std::srand(std::time(0));
 
-  for (int cr = 0; cr < i_recombinationParameters.getRecombinationParameters();
+  for (int32_t cr = 0;
+       cr < i_recombinationParameters.getRecombinationParameters();
        ++cr) {
-    child3                      = 0;
-    std::vector<int> parentsInt = ParentsTypesWorker(
+    child3                          = 0;
+    std::vector<int32_t> parentsInt = ParentsTypesWorker(
         i_recombinationParameters.getParentsParameters(), i_population
     );
-    int child1 = parentsInt[0];
-    int child2 = parentsInt[1];
+    int32_t child1 = parentsInt[0];
+    int32_t child2 = parentsInt[1];
 
     while (child1 == child3 || child2 == child3)
       child3 = rand() % i_population.size();
@@ -136,8 +139,8 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>>
     parents.push_back(i_population[child2].getChronosomeType().getOutTable());
     std::vector<std::vector<bool>> child(size, std::vector<bool>(output));
 
-    for (int i = 0; i < size; ++i) {
-      for (int j = 0; j < output; ++j) {
+    for (int32_t i = 0; i < size; ++i) {
+      for (int32_t j = 0; j < output; ++j) {
         child[i][j] = parents[mask.getOutTable(i, j) ? 0 : 1][i][j];
       }
     }
@@ -162,31 +165,32 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>>
     ) {
   std::srand(std::time(0));
 
-  int input          = i_population[0].getChronosomeType().getInput();
-  int output         = i_population[0].getChronosomeType().getOutput();
-  int size           = i_population[0].getChronosomeType().size();
-  int referencePoint = rand() % size;
+  int32_t input          = i_population[0].getChronosomeType().getInput();
+  int32_t output         = i_population[0].getChronosomeType().getOutput();
+  int32_t size           = i_population[0].getChronosomeType().size();
+  int32_t referencePoint = rand() % size;
 
   std::vector<ChronosomeType<TruthTable, TruthTableParameters>> survivors;
 
-  for (int cr = 0; cr < i_recombinationParameters.getRecombinationParameters();
+  for (int32_t cr = 0;
+       cr < i_recombinationParameters.getRecombinationParameters();
        ++cr) {
-    std::vector<int> parentsInt = ParentsTypesWorker(
+    std::vector<int32_t> parentsInt = ParentsTypesWorker(
         i_recombinationParameters.getParentsParameters(), i_population
     );
-    int                                         child1 = parentsInt[0];
-    int                                         child2 = parentsInt[1];
+    int32_t                                     child1 = parentsInt[0];
+    int32_t                                     child2 = parentsInt[1];
 
     std::vector<std::vector<std::vector<bool>>> parents;
     parents.push_back(i_population[child1].getChronosomeType().getOutTable());
     parents.push_back(i_population[child2].getChronosomeType().getOutTable());
     std::vector<std::vector<bool>> child(size, std::vector<bool>(output));
 
-    for (int j = 0; j < output; ++j) {
+    for (int32_t j = 0; j < output; ++j) {
       while (parents[0][referencePoint][j] == parents[1][referencePoint][j])
         referencePoint = rand() % size;
 
-      for (int i = 0; i < size; ++i)
+      for (int32_t i = 0; i < size; ++i)
         child[i][j] = parents[i < referencePoint ? 0 : 1][i][j];
     }
     TruthTable                                       tt(input, output, child);
@@ -206,20 +210,21 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>>
     ) {
   std::srand(std::time(0));
 
-  int input          = i_population[0].getChronosomeType().getInput();
-  int output         = i_population[0].getChronosomeType().getOutput();
-  int size           = i_population[0].getChronosomeType().size();
-  int referencePoint = rand() % size;
+  int32_t input          = i_population[0].getChronosomeType().getInput();
+  int32_t output         = i_population[0].getChronosomeType().getOutput();
+  int32_t size           = i_population[0].getChronosomeType().size();
+  int32_t referencePoint = rand() % size;
 
   std::vector<ChronosomeType<TruthTable, TruthTableParameters>> survivors;
 
-  for (int cr = 0; cr < i_recombinationParameters.getRecombinationParameters();
+  for (int32_t cr = 0;
+       cr < i_recombinationParameters.getRecombinationParameters();
        ++cr) {
-    std::vector<int> parentsInt = ParentsTypesWorker(
+    std::vector<int32_t> parentsInt = ParentsTypesWorker(
         i_recombinationParameters.getParentsParameters(), i_population
     );
-    int child1     = parentsInt[0];
-    int child2     = parentsInt[1];
+    int32_t child1 = parentsInt[0];
+    int32_t child2 = parentsInt[1];
 
     referencePoint = rand() % size;
     std::vector<std::vector<std::vector<bool>>> parents;
@@ -227,15 +232,15 @@ std::vector<ChronosomeType<TruthTable, TruthTableParameters>>
     parents.push_back(i_population[child2].getChronosomeType().getOutTable());
     std::vector<std::vector<bool>> child(size, std::vector<bool>(output));
 
-    for (int i = 0; i < size; ++i) {
-      for (int j = 0; j < output; ++j) {
+    for (int32_t i = 0; i < size; ++i) {
+      for (int32_t j = 0; j < output; ++j) {
         if (rand() % 2)
           swap(parents[0][i][j], parents[1][i][j]);
       }
     }
 
-    for (int i = 0; i < size; ++i) {
-      for (int j = 0; j < output; ++j) {
+    for (int32_t i = 0; i < size; ++i) {
+      for (int32_t j = 0; j < output; ++j) {
         child[i][j] = parents[i < referencePoint ? 0 : 1][i][j];
       }
     }

--- a/src/generators/Genetic/Selections/SelectionParameters.cpp
+++ b/src/generators/Genetic/Selections/SelectionParameters.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <tuple>
 
 #include "SelectionParameters.h"
@@ -10,11 +11,11 @@ SelectionTypes SelectionParameters::getSelectionType() const {
   return d_selectionType;
 }
 
-int SelectionParameters::getNumOfSurvivors() const {
+int32_t SelectionParameters::getNumOfSurvivors() const {
   return d_numOfSurvivors;
 }
 
-void SelectionParameters::setNumOfSurvivors(int i_survivors) {
+void SelectionParameters::setNumOfSurvivors(int32_t i_survivors) {
   d_numOfSurvivors = i_survivors;
 }
 

--- a/src/generators/Genetic/Selections/SelectionParameters.h
+++ b/src/generators/Genetic/Selections/SelectionParameters.h
@@ -9,12 +9,12 @@ enum SelectionTypes
 class SelectionParameters
 {
 public:
-  int getNumOfSurvivors() const;
-  void setNumOfSurvivors(int i_survivors);
+  int32_t getNumOfSurvivors() const;
+  void setNumOfSurvivors(int32_t i_survivors);
   bool operator== (const SelectionParameters& r) const;
   void setSelectionType(SelectionTypes i_selectionType);
   SelectionTypes getSelectionType() const;
 private:
   SelectionTypes d_selectionType = SelectionTypes::Base;
-  int d_numOfSurvivors = 0;
+  int32_t d_numOfSurvivors = 0;
 };

--- a/src/generators/Genetic/Selections/SelectionsTruthTable.h
+++ b/src/generators/Genetic/Selections/SelectionsTruthTable.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <algorithm>
 #include "../ChronosomeType.h"
 
 namespace SelectionsTruthTable
@@ -14,7 +14,7 @@ inline std::vector<ChronosomeType<TruthTable, TruthTableParameters>> SelectionBa
   std::vector<ChronosomeType<TruthTable, TruthTableParameters>> survivors;
   while (survivors.size() < i_selectionParameters.getNumOfSurvivors())
   {
-    int r1 = 0, r2 = 0;
+    int32_t r1 = 0, r2 = 0;
     while (i_population.size() > 2 && r2 == r1)
     {
       r1 = rand() % i_population.size();

--- a/src/generators/simple/SimpleGenerators.cpp
+++ b/src/generators/simple/SimpleGenerators.cpp
@@ -265,12 +265,12 @@ GraphPtr SimpleGenerators::zhegalkinFromTruthTable(const TruthTable& i_table) {
 }
 
 GraphPtr SimpleGenerators::generatorRandLevel(
-    int32_t i_minLevel,
-    int32_t i_maxLevel,
-    int32_t i_minElements,
-    int32_t i_maxElements,
-    int32_t i_inputs,
-    int32_t i_outputs
+    uint32_t i_minLevel,
+    uint32_t i_maxLevel,
+    uint32_t i_minElements,
+    uint32_t i_maxElements,
+    uint32_t i_inputs,
+    uint32_t i_outputs
 ) {
   int32_t maxLevel;
 
@@ -507,8 +507,8 @@ GraphPtr SimpleGenerators::generatorRandLevelExperimental(
 }
 
 GraphPtr SimpleGenerators::generatorNumOperation(
-    int32_t                  i_input,
-    int32_t                  i_output,
+    uint32_t                  i_input,
+    uint32_t                  i_output,
     std::map<Gates, int32_t> i_logicOper,
     bool                 i_leaveEmptyOut
 ) {
@@ -630,7 +630,7 @@ std::map<Gates, int32_t> SimpleGenerators::delNull(
 }
 
 GraphPtr SimpleGenerators::generatorSummator(
-    int32_t  i_bits,
+    uint32_t  i_bits,
     bool i_overflowIn,
     bool i_overflowOut,
     bool i_minus
@@ -722,7 +722,7 @@ GraphPtr SimpleGenerators::generatorSummator(
 }
 
 GraphPtr SimpleGenerators::generatorComparison(
-    int32_t  i_bits,
+    uint32_t  i_bits,
     bool compare0,
     bool compare1,
     bool compare2
@@ -820,7 +820,7 @@ GraphPtr SimpleGenerators::generatorComparison(
   return graph;
 }
 
-GraphPtr SimpleGenerators::generatorEncoder(int32_t i_bits) {
+GraphPtr SimpleGenerators::generatorEncoder(uint32_t i_bits) {
   GraphPtr graph(new OrientedGraph);
   if (i_bits < 2) {
     std::cout << "Недостаточно входных сигналов" << std::endl;
@@ -834,7 +834,7 @@ GraphPtr SimpleGenerators::generatorEncoder(int32_t i_bits) {
     std::vector<VertexPtr> ands(pow(2, i_outbits));
 
     // создание инверсий входов
-    for (int32_t i = 0; i < i_bits; i++) {
+    for (uint32_t i = 0; i < i_bits; i++) {
       VertexPtr x = graph->addInput("x" + std::to_string(i + 1));
       inputs_x[i] = x;
       VertexPtr nx =
@@ -899,7 +899,7 @@ GraphPtr SimpleGenerators::generatorEncoder(int32_t i_bits) {
 }
 
 GraphPtr SimpleGenerators::generatorSubtractor(
-    int32_t  i_bits,
+    uint32_t  i_bits,
     bool i_overflowIn,
     bool i_overflowOut,
     bool i_sub
@@ -920,7 +920,7 @@ GraphPtr SimpleGenerators::generatorSubtractor(
   VertexPtr next_z;  // следующий заем
   VertexPtr curr_z;  // нынешний заём
 
-  for (int32_t i = 0; i < i_bits; i++) {
+  for (uint32_t i = 0; i < i_bits; i++) {
     std::string Z = std::to_string(i);          // нынешний индекс
     std::string NextZ = std::to_string(i + 1);  // следующий индекс
     std::string x       = "suba" + cond + Z;
@@ -1000,12 +1000,12 @@ GraphPtr SimpleGenerators::generatorSubtractor(
   return graph;
 }
 
-GraphPtr SimpleGenerators::generatorMultiplexer(int32_t i_bits) {
+GraphPtr SimpleGenerators::generatorMultiplexer(uint32_t i_bits) {
   GraphPtr               graph(new OrientedGraph);
   VertexPtr              output_f = graph->addOutput("f");
   std::vector<VertexPtr> inputs_x;
   int32_t                    k = 0;
-  for (int32_t t = 0; t <= i_bits; t++) {
+  for (uint32_t t = 0; t <= i_bits; t++) {
     if (i_bits - 1 >= std::pow(2, t))
       k++;
   }
@@ -1067,7 +1067,7 @@ GraphPtr SimpleGenerators::generatorMultiplexer(int32_t i_bits) {
   return graph;
 }
 
-GraphPtr SimpleGenerators::generatorDemultiplexer(int32_t i_bits) {
+GraphPtr SimpleGenerators::generatorDemultiplexer(uint32_t i_bits) {
   // i_bits - количество выходных сигналов, то есть количество х
   // f - значение функции на входе
   // i_outbits - количество адресных входов, то есть количество а
@@ -1085,7 +1085,7 @@ GraphPtr SimpleGenerators::generatorDemultiplexer(int32_t i_bits) {
   VertexPtr input_f = graph->addInput("f");
 
   int32_t       k       = 0;
-  for (int32_t t = 0; t <= i_bits; t++) {
+  for (uint32_t t = 0; t <= i_bits; t++) {
     if (i_bits - 1 >= std::pow(2, t))
       k++;
   }
@@ -1139,7 +1139,7 @@ GraphPtr SimpleGenerators::generatorDemultiplexer(int32_t i_bits) {
   return graph;
 }
 
-GraphPtr SimpleGenerators::generatorDecoder(int32_t i_bits) {
+GraphPtr SimpleGenerators::generatorDecoder(uint32_t i_bits) {
   // bits - количество входов
   // T[]- массив для текущего ряда узлов
   // X[]- массив для предыдущего ряда узлов
@@ -1192,7 +1192,7 @@ GraphPtr SimpleGenerators::generatorDecoder(int32_t i_bits) {
   return graph;
 }
 
-GraphPtr SimpleGenerators::generatorParity(int32_t i_bits) {
+GraphPtr SimpleGenerators::generatorParity(uint32_t i_bits) {
   // i_bits - количество входов
   // elem - массив для сохранения вершин
   // xors - промежуточный массив для сохранения вершин
@@ -1207,7 +1207,7 @@ GraphPtr SimpleGenerators::generatorParity(int32_t i_bits) {
   std::vector<VertexPtr> elem(i_bits);
   std::vector<VertexPtr> xors;
 
-  for (int32_t i = 0; i < i_bits; i++) {
+  for (uint32_t i = 0; i < i_bits; i++) {
     elem[i] = graph->addInput("x" + std::to_string(i));
   }
 
@@ -1237,7 +1237,7 @@ GraphPtr SimpleGenerators::generatorParity(int32_t i_bits) {
   return graph;
 }
 
-GraphPtr SimpleGenerators::generatorMultiplier(int32_t i_bits) {
+GraphPtr SimpleGenerators::generatorMultiplier(uint32_t i_bits) {
   GraphPtr               graph(new OrientedGraph);
   VertexPtr              const_1;
 

--- a/src/generators/simple/SimpleGenerators.cpp
+++ b/src/generators/simple/SimpleGenerators.cpp
@@ -65,7 +65,7 @@ std::pair<Gates, int32_t> SimpleGenerators::getRandomElement(
 }
 
 std::pair<Gates, int32_t> SimpleGenerators::getRandomElement(
-    u_int32_t i_gatesLimit
+    uint32_t i_gatesLimit
 ) {
   if (i_gatesLimit >= d_maxGateNumber)
     return getRandomElement(d_gatesInputsInfo);
@@ -353,19 +353,19 @@ GraphPtr SimpleGenerators::generatorRandLevel(
 }
 
 GraphPtr SimpleGenerators::generatorRandLevelExperimental(
-    u_int32_t i_minLevel,
-    u_int32_t i_maxLevel,
-    u_int32_t i_minElements,
-    u_int32_t i_maxElements,
-    u_int32_t i_inputs,
-    u_int32_t i_outputs
+    uint32_t i_minLevel,
+    uint32_t i_maxLevel,
+    uint32_t i_minElements,
+    uint32_t i_maxElements,
+    uint32_t i_inputs,
+    uint32_t i_outputs
 ) {
   if (i_minLevel > i_maxLevel)
     throw std::invalid_argument("min level is biggert than max level");
   if (i_minElements > i_maxElements)
     throw std::invalid_argument("min elem is biggert than max elem");
 
-  u_int32_t maxLevel;
+  uint32_t maxLevel;
   if (i_maxLevel)
     maxLevel = d_randGenerator.getRandInt(i_minLevel, i_maxLevel, true) + 1;
   else
@@ -389,18 +389,18 @@ GraphPtr SimpleGenerators::generatorRandLevelExperimental(
   for (auto i : graph->getVerticesByType(VertexTypes::input)) {
     inputs.push_back(i);
   }
-  auto      curGates(inputs);
+  auto     curGates(inputs);
 
   // TODO what if we will need to use n-gate elements, should we add consts
   // usage?
 
-  int32_t   currIndex = i_inputs;
-  int32_t   curLen    = 0;
+  int32_t  currIndex = i_inputs;
+  int32_t  curLen    = 0;
   // we need lowest border as d_maxGateNumber, and if it is possible,
   // we set it (it changes speed of generation)
-  u_int32_t c_max     = i_maxElements > d_maxGateNumber
-                          ? std::max(d_maxGateNumber, (int32_t)i_minElements)
-                          : i_minElements;
+  uint32_t c_max     = i_maxElements > d_maxGateNumber
+                         ? std::max(d_maxGateNumber, (int32_t)i_minElements)
+                         : i_minElements;
 
   for (int32_t i = 1; i < maxLevel; ++i) {
     // how many elements would be at this level

--- a/src/generators/simple/SimpleGenerators.cpp
+++ b/src/generators/simple/SimpleGenerators.cpp
@@ -15,43 +15,43 @@
 #include <generators/Genetic/GeneticParameters.h>
 #include <math.h>
 
-int SimpleGenerators::getRangomAndNumber() {
+int32_t SimpleGenerators::getRangomAndNumber() {
   return d_gatesInputsInfo[Gates::GateAnd][d_randGenerator.getRandInt(
       0, d_gatesInputsInfo[Gates::GateAnd].size()
   )];
 }
 
-int SimpleGenerators::getRangomOrNumber() {
+int32_t SimpleGenerators::getRangomOrNumber() {
   return d_gatesInputsInfo[Gates::GateOr][d_randGenerator.getRandInt(
       0, d_gatesInputsInfo[Gates::GateOr].size()
   )];
 }
 
-int SimpleGenerators::getRangomNandNumber() {
+int32_t SimpleGenerators::getRangomNandNumber() {
   return d_gatesInputsInfo[Gates::GateNand][d_randGenerator.getRandInt(
       0, d_gatesInputsInfo[Gates::GateNand].size()
   )];
 }
 
-int SimpleGenerators::getRangomNorNumber() {
+int32_t SimpleGenerators::getRangomNorNumber() {
   return d_gatesInputsInfo[Gates::GateNor][d_randGenerator.getRandInt(
       0, d_gatesInputsInfo[Gates::GateNor].size()
   )];
 }
 
-int SimpleGenerators::getRangomXorNumber() {
+int32_t SimpleGenerators::getRangomXorNumber() {
   return d_gatesInputsInfo[Gates::GateXor][d_randGenerator.getRandInt(
       0, d_gatesInputsInfo[Gates::GateXor].size()
   )];
 }
 
-int SimpleGenerators::getRangomXnorNumber() {
+int32_t SimpleGenerators::getRangomXnorNumber() {
   return d_gatesInputsInfo[Gates::GateXnor][d_randGenerator.getRandInt(
       0, d_gatesInputsInfo[Gates::GateXnor].size()
   )];
 }
 
-std::pair<Gates, int> SimpleGenerators::getRandomElement(const GatesInfo& i_info
+std::pair<Gates, int32_t> SimpleGenerators::getRandomElement(const GatesInfo& i_info
 ) {
   // rand element of map
   auto val = i_info.begin();
@@ -63,7 +63,7 @@ std::pair<Gates, int> SimpleGenerators::getRandomElement(const GatesInfo& i_info
   );
 }
 
-std::pair<Gates, int> SimpleGenerators::getRandomElement(u_int32_t i_gatesLimit
+std::pair<Gates, int32_t> SimpleGenerators::getRandomElement(u_int32_t i_gatesLimit
 ) {
   if (i_gatesLimit >= d_maxGateNumber)
     return getRandomElement(d_gatesInputsInfo);
@@ -74,10 +74,10 @@ std::pair<Gates, int> SimpleGenerators::getRandomElement(u_int32_t i_gatesLimit
     );
 
   GatesInfo        info;
-  std::vector<int> subval;
+  std::vector<int32_t> subval;
 
   for (auto [key, value] : d_gatesInputsInfo) {
-    for (int i = 0; i < value.size() && value[i] <= i_gatesLimit; ++i)
+    for (size_t i = 0; i < value.size() && value[i] <= i_gatesLimit; ++i)
       subval.push_back(value[i]);
 
     if (subval.size())
@@ -92,7 +92,7 @@ SimpleGenerators::SimpleGenerators() {
   d_randGenerator.setSeed(AuxMethods::getRandSeed());
 }
 
-SimpleGenerators::SimpleGenerators(int i_seed) {
+SimpleGenerators::SimpleGenerators(uint_fast32_t i_seed) {
   d_randGenerator.setSeed(i_seed);
 }
 
@@ -105,7 +105,7 @@ GraphPtr
   GraphPtr                       graph(new OrientedGraph());
   std::vector<VertexPtr>         inputs;
   inputs.reserve(i_table.getInput());
-  for (int k = 0; k < i_table.getInput(); ++k) {
+  for (size_t k = 0; k < i_table.getInput(); ++k) {
     inputs.push_back(graph->addInput("x" + std::to_string(k)));
   }
 
@@ -125,10 +125,10 @@ GraphPtr
 
   for (size_t j = 0; j < i_table.getOutput(); ++j) {
     VertexPtr out = graph->addOutput("f" + std::to_string(j));
-    int       mem = 0;
-    int       tmp = 0;
+    int32_t       mem = 0;
+    int32_t       tmp = 0;
 
-    for (int i = 0; i < i_table.size(); ++i) {
+    for (int32_t i = 0; i < i_table.size(); ++i) {
       if (!(i_table.getOutTable(i, j) ^ i_tp))
         mem++;
     }
@@ -158,7 +158,7 @@ GraphPtr
     nextLayout.reserve(inputs.size());
 
     // Here we create operations in brackets
-    for (int i = 0; i < mem; ++i) {
+    for (int32_t i = 0; i < mem; ++i) {
       while ((i_table.getOutTable(tmp, j) ^ i_tp) && tmp < i_table.size())
         ++tmp;
 
@@ -199,22 +199,22 @@ GraphPtr
 }
 
 GraphPtr SimpleGenerators::zhegalkinFromTruthTable(const TruthTable& i_table) {
-  int                    num_inputs  = i_table.getInput();
-  int                    num_outputs = i_table.getOutput();
+  int32_t                    num_inputs  = i_table.getInput();
+  int32_t                    num_outputs = i_table.getOutput();
 
   GraphPtr               graph(new OrientedGraph());
   std::vector<VertexPtr> inputs;
   inputs.reserve(num_inputs);
 
-  for (int k = 0; k < num_inputs; ++k) {
+  for (int32_t k = 0; k < num_inputs; ++k) {
     inputs.push_back(graph->addInput("x" + std::to_string(k)));
   }
 
-  for (int j = 0; j < num_outputs; ++j) {
+  for (int32_t j = 0; j < num_outputs; ++j) {
     VertexPtr out = graph->addOutput("f" + std::to_string(j));
 
-    int       mem = 0;
-    for (int i = 0; i < i_table.size(); ++i) {
+    int32_t       mem = 0;
+    for (int32_t i = 0; i < i_table.size(); ++i) {
       mem += i_table.getOutTable(i, j);
     }
 
@@ -227,7 +227,7 @@ GraphPtr SimpleGenerators::zhegalkinFromTruthTable(const TruthTable& i_table) {
     } else {
       bool first_term = true;
 
-      for (int term = 0; term < (1 << num_inputs); ++term) {
+      for (int32_t term = 0; term < (1 << num_inputs); ++term) {
         if (i_table.getOutTable(term, j)) {
           if (!first_term) {
             VertexPtr xorOper = graph->addGate(Gates::GateXor);
@@ -241,7 +241,7 @@ GraphPtr SimpleGenerators::zhegalkinFromTruthTable(const TruthTable& i_table) {
           } else {
             VertexPtr andOper = graph->addGate(Gates::GateAnd);
 
-            for (int i = 0; i < num_inputs; ++i) {
+            for (int32_t i = 0; i < num_inputs; ++i) {
               VertexPtr x_input = inputs[i];
               bool      negated = ((term >> (num_inputs - i - 1)) & 1) == 0;
 
@@ -265,14 +265,14 @@ GraphPtr SimpleGenerators::zhegalkinFromTruthTable(const TruthTable& i_table) {
 }
 
 GraphPtr SimpleGenerators::generatorRandLevel(
-    int i_minLevel,
-    int i_maxLevel,
-    int i_minElements,
-    int i_maxElements,
-    int i_inputs,
-    int i_outputs
+    int32_t i_minLevel,
+    int32_t i_maxLevel,
+    int32_t i_minElements,
+    int32_t i_maxElements,
+    int32_t i_inputs,
+    int32_t i_outputs
 ) {
-  int maxLevel;
+  int32_t maxLevel;
 
   if (i_minLevel > i_maxLevel)
     throw std::invalid_argument("min level is biggert than max level");
@@ -288,28 +288,28 @@ GraphPtr SimpleGenerators::generatorRandLevel(
 
   // maxLevel++ // what?
 
-  int         choice;
+  int32_t         choice;
   std::string expr;
   GraphPtr    graph(new OrientedGraph);
-  int         child1, child2;
+  int32_t         child1, child2;
 
-  for (int i = 0; i < i_inputs; ++i) {
+  for (int32_t i = 0; i < i_inputs; ++i) {
     expr = "x" + std::to_string(i);
     graph->addInput(expr);
   }
 
-  int currIndex = i_inputs;
-  int prevIndex = 0;
+  int32_t currIndex = i_inputs;
+  int32_t prevIndex = 0;
 
-  for (int i = 1; i < maxLevel; ++i) {
-    int position = 0;
+  for (int32_t i = 1; i < maxLevel; ++i) {
+    int32_t position = 0;
     // how many elements would be at this level
-    int elemLevel =
+    int32_t elemLevel =
         i_maxElements > 1
             ? d_randGenerator.getRandInt(i_minElements, i_maxElements, true)
             : 2;
 
-    for (int j = 0; j < elemLevel; ++j) {
+    for (int32_t j = 0; j < elemLevel; ++j) {
       choice = d_randGenerator.getRandInt(0, logOper.size());
 
       if (hasOneGate[choice]) {
@@ -340,7 +340,7 @@ GraphPtr SimpleGenerators::generatorRandLevel(
 
   // TODO: fix when elements less than outputs
 
-  for (int i = 0; i < i_outputs; ++i) {
+  for (int32_t i = 0; i < i_outputs; ++i) {
     child1              = d_randGenerator.getRandInt(prevIndex, currIndex);
     expr                = "f" + std::to_string(i + 1);
     VertexPtr newVertex = graph->addOutput(expr);
@@ -372,7 +372,7 @@ GraphPtr SimpleGenerators::generatorRandLevelExperimental(
   std::string expr;
   GraphPtr    graph(new OrientedGraph);
 
-  for (int i = 0; i < i_inputs; ++i) {
+  for (uint32_t i = 0; i < i_inputs; ++i) {
     expr = "x" + std::to_string(i);
     graph->addInput(expr);
   }
@@ -392,17 +392,17 @@ GraphPtr SimpleGenerators::generatorRandLevelExperimental(
   // TODO what if we will need to use n-gate elements, should we add consts
   // usage?
 
-  int       currIndex = i_inputs;
-  int       curLen    = 0;
+  int32_t       currIndex = i_inputs;
+  int32_t       curLen    = 0;
   // we need lowest border as d_maxGateNumber, and if it is possible,
   // we set it (it changes speed of generation)
   u_int32_t c_max     = i_maxElements > d_maxGateNumber
-                          ? std::max(d_maxGateNumber, (int)i_minElements)
+                          ? std::max(d_maxGateNumber, (int32_t)i_minElements)
                           : i_minElements;
 
-  for (int i = 1; i < maxLevel; ++i) {
+  for (int32_t i = 1; i < maxLevel; ++i) {
     // how many elements would be at this level
-    int                        elemLevel = i_maxElements > 1
+    int32_t                        elemLevel = i_maxElements > 1
                                              ? d_randGenerator.getRandInt(c_max, i_maxElements, true)
                                              : i_maxElements;
 
@@ -410,19 +410,19 @@ GraphPtr SimpleGenerators::generatorRandLevelExperimental(
     std::vector<VertexPtrWeak> futureGates;
     curLen += curGates.size();
 
-    for (int j = 0; j < elemLevel; ++j) {
+    for (int32_t j = 0; j < elemLevel; ++j) {
       // we use inputs only if we are not on the first level
       auto [operation, gatesNumber] = getRandomElement(curLen);
       // from which element we should start shuffle
       // like we do not shuffle whole list, if it is possible
       // but only it's part
-      int fromWhichShuffle          = d_randGenerator.getRandInt(
-          0, std::max(1, (int)curGates.size() - gatesNumber)
+      int32_t fromWhichShuffle          = d_randGenerator.getRandInt(
+          0, std::max(1, (int32_t)curGates.size() - gatesNumber)
       );
       // shuffle curGates
-      for (int k       = fromWhichShuffle,
+      for (int32_t k       = fromWhichShuffle,
                stopVal = std::min(
-                   fromWhichShuffle + gatesNumber, (int)curGates.size()
+                   fromWhichShuffle + gatesNumber, (int32_t)curGates.size()
                );
            k < stopVal;
            ++k) {
@@ -435,7 +435,7 @@ GraphPtr SimpleGenerators::generatorRandLevelExperimental(
       VertexPtr newVertex = graph->addGate(operation);
 
       if (gatesNumber == 1) {
-        int child1 = d_randGenerator.getRandInt(0, currIndex);
+        int32_t child1 = d_randGenerator.getRandInt(0, currIndex);
 
         graph->addEdge(graph->getVerticeByIndex(child1), newVertex);
       } else {
@@ -454,12 +454,12 @@ GraphPtr SimpleGenerators::generatorRandLevelExperimental(
         ++idx;
 
         // add multiple parents
-        for (int l = 1; l < gatesNumber; ++l, ++idx) {
+        for (int32_t l = 1; l < gatesNumber; ++l, ++idx) {
           // if we are at the end of vector
           if (idx == curGates.end()) {
             // and we added some vertices, e.g. we are not on the first level
             if (i > 1) {
-              for (int k = 0; k < inputs.size(); ++k)
+              for (int32_t k = 0; k < inputs.size(); ++k)
                 std::swap(
                     inputs[k],
                     inputs[d_randGenerator.getRandInt(0, inputs.size())]
@@ -493,7 +493,7 @@ GraphPtr SimpleGenerators::generatorRandLevelExperimental(
   }
 
   // std::clog << "writing out gates" << std::endl;
-  for (int i = 0; i < i_outputs; ++i) {
+  for (int32_t i = 0; i < i_outputs; ++i) {
     auto child1 =
         curGates[d_randGenerator.getRandInt(0, curGates.size())].lock();
     expr                = "f" + std::to_string(i + 1);
@@ -507,16 +507,16 @@ GraphPtr SimpleGenerators::generatorRandLevelExperimental(
 }
 
 GraphPtr SimpleGenerators::generatorNumOperation(
-    int                  i_input,
-    int                  i_output,
-    std::map<Gates, int> i_logicOper,
+    int32_t                  i_input,
+    int32_t                  i_output,
+    std::map<Gates, int32_t> i_logicOper,
     bool                 i_leaveEmptyOut
 ) {
-  int                              sumOper = 0, maxLvl;
+  int32_t                              sumOper = 0, maxLvl;
   std::string                      name;
   VertexPtr                        name_ptr;
-  std::map<Gates, int>             copyLogicOper;
-  std::map<std::string, int>       levelName;
+  std::map<Gates, int32_t>             copyLogicOper;
+  std::map<std::string, int32_t>       levelName;
   std::map<std::string, VertexPtr> levelNamePtr;
   std::vector<VertexPtr>           nameOut, nameInput;
 
@@ -528,7 +528,7 @@ GraphPtr SimpleGenerators::generatorNumOperation(
 
   GraphPtr graph(new OrientedGraph());
 
-  for (int i = 0; i < i_input; ++i) {
+  for (int32_t i = 0; i < i_input; ++i) {
     name                              = "x" + std::to_string(i);
     name_ptr                          = graph->addInput(name);
 
@@ -539,7 +539,7 @@ GraphPtr SimpleGenerators::generatorNumOperation(
       nameInput.push_back(name_ptr);
   }
 
-  for (int i = 0; i < i_output; ++i) {
+  for (int32_t i = 0; i < i_output; ++i) {
     name     = "f" + std::to_string(i);
     name_ptr = graph->addOutput(name);
     nameOut.push_back(name_ptr);
@@ -550,7 +550,7 @@ GraphPtr SimpleGenerators::generatorNumOperation(
 
   copyLogicOper = delNull(copyLogicOper);
   // TODO it is TOO slow
-  for (int i = 0; i < sumOper; ++i) {
+  for (int32_t i = 0; i < sumOper; ++i) {
     // TODO: optimize
     // TODO change whole gen
     Gates oper = randomGenerator(copyLogicOper);
@@ -598,16 +598,16 @@ GraphPtr SimpleGenerators::generatorNumOperation(
       }
 
       while (help.size() > 0 && nameOut.size() > 0) {
-        int R1 = d_randGenerator.getRandInt(0, help.size());
-        int R2 = d_randGenerator.getRandInt(0, nameOut.size());
+        int32_t R1 = d_randGenerator.getRandInt(0, help.size());
+        int32_t R2 = d_randGenerator.getRandInt(0, nameOut.size());
         graph->addEdge(levelNamePtr[help[R1]], nameOut[R2]);
         levelName.erase(help[R1]);
         help.erase(help.begin() + R1);
         nameOut.erase(nameOut.begin() + R2);
       }
     } else {
-      int R1 = d_randGenerator.getRandInt(0, nameInput.size());
-      int R2 = d_randGenerator.getRandInt(0, nameOut.size());
+      int32_t R1 = d_randGenerator.getRandInt(0, nameInput.size());
+      int32_t R2 = d_randGenerator.getRandInt(0, nameOut.size());
 
       graph->addEdge(nameInput[R1], nameOut[R2]);
       nameOut.erase(nameOut.begin() + R2);
@@ -616,8 +616,8 @@ GraphPtr SimpleGenerators::generatorNumOperation(
   return graph;
 }
 
-std::map<Gates, int> SimpleGenerators::delNull(
-    std::map<Gates, int> i_copyLogicOper
+std::map<Gates, int32_t> SimpleGenerators::delNull(
+    std::map<Gates, int32_t> i_copyLogicOper
 ) {
   std::vector<Gates> delList;
   for (const auto& [key, value] : i_copyLogicOper)
@@ -630,7 +630,7 @@ std::map<Gates, int> SimpleGenerators::delNull(
 }
 
 GraphPtr SimpleGenerators::generatorSummator(
-    int  i_bits,
+    int32_t  i_bits,
     bool i_overflowIn,
     bool i_overflowOut,
     bool i_minus
@@ -653,7 +653,7 @@ GraphPtr SimpleGenerators::generatorSummator(
   VertexPtr curr_p;
   VertexPtr next_p;
 
-  for (int i = 0; i < i_bits; i++) {
+  for (int32_t i = 0; i < i_bits; i++) {
     std::string S     = std::to_string(i);
     std::string NextS = std::to_string(i + 1);
 
@@ -722,7 +722,7 @@ GraphPtr SimpleGenerators::generatorSummator(
 }
 
 GraphPtr SimpleGenerators::generatorComparison(
-    int  i_bits,
+    int32_t  i_bits,
     bool compare0,
     bool compare1,
     bool compare2
@@ -731,7 +731,7 @@ GraphPtr SimpleGenerators::generatorComparison(
   VertexPtr   prev_pn_;
   std::string cond = std::string(compare0 ? "t" : "f") + (compare1 ? "t" : "f")
                    + (compare2 ? "t" : "f");
-  for (int i = i_bits - 1; i >= 0; i--) {
+  for (int32_t i = i_bits - 1; i >= 0; i--) {
     std::string C     = std::to_string(i);
     std::string NextC = std::to_string(i - 1);
     std::string x     = "coma" + cond + C;
@@ -820,12 +820,12 @@ GraphPtr SimpleGenerators::generatorComparison(
   return graph;
 }
 
-GraphPtr SimpleGenerators::generatorEncoder(int i_bits) {
+GraphPtr SimpleGenerators::generatorEncoder(int32_t i_bits) {
   GraphPtr graph(new OrientedGraph);
   if (i_bits < 2) {
     std::cout << "Недостаточно входных сигналов" << std::endl;
   } else {
-    int i_outbits = 0;
+    int32_t i_outbits = 0;
     while (i_bits > pow(2, i_outbits))
       i_outbits++;
 
@@ -834,7 +834,7 @@ GraphPtr SimpleGenerators::generatorEncoder(int i_bits) {
     std::vector<VertexPtr> ands(pow(2, i_outbits));
 
     // создание инверсий входов
-    for (int i = 0; i < i_bits; i++) {
+    for (int32_t i = 0; i < i_bits; i++) {
       VertexPtr x = graph->addInput("x" + std::to_string(i + 1));
       inputs_x[i] = x;
       VertexPtr nx =
@@ -843,15 +843,15 @@ GraphPtr SimpleGenerators::generatorEncoder(int i_bits) {
       not_x[i] = nx;
     }
 
-    int  shift = 1;
-    int  count = 0;
+    int32_t  shift = 1;
+    int32_t  count = 0;
     bool check = false;
-    for (int i = 0; i < pow(2, i_outbits); i++) {
+    for (int32_t i = 0; i < pow(2, i_outbits); i++) {
       VertexPtr and_xs =
           graph->addGate(Gates::GateAnd, "and_for_or" + std::to_string(i + 1));
       // создание массива значений для операций and
       std::vector<VertexPtr> Xs(i_bits);
-      for (int j = 0; j < i_bits; j++) {
+      for (int32_t j = 0; j < i_bits; j++) {
         if (i < i_bits)
           Xs[j] = (j == i) ? inputs_x[j] : not_x[j];
         else {
@@ -865,9 +865,9 @@ GraphPtr SimpleGenerators::generatorEncoder(int i_bits) {
         // операции and для заполнения недостающих результатов для выходов
         Xs[0]     = inputs_x[0];
         Xs[shift] = inputs_x[shift];
-        for (int j = shift + 1; j < i_bits; j++)
+        for (int32_t j = shift + 1; j < i_bits; j++)
           Xs[j] = not_x[j];
-        for (int j = 1; j < shift; j++)
+        for (int32_t j = 1; j < shift; j++)
           Xs[j] = (j <= count) ? inputs_x[j] : Xs[j] = not_x[j];
         count++;
         if (shift == count) {
@@ -879,13 +879,13 @@ GraphPtr SimpleGenerators::generatorEncoder(int i_bits) {
       ands[i] = and_xs;
     }
 
-    int n = 1;
-    for (int i = 0; i < i_outbits; i++) {
+    int32_t n = 1;
+    for (int32_t i = 0; i < i_outbits; i++) {
       VertexPtr or_xs = graph->addGate(
           Gates::GateOr, "or_for_output" + std::to_string(i + 1)
       );
       std::vector<VertexPtr> ors;
-      for (int j = n; j < pow(2, i_outbits); j += n * 2) {
+      for (int32_t j = n; j < pow(2, i_outbits); j += n * 2) {
         ors.insert(ors.end(), ands.begin() + j, ands.begin() + j + n);
       }
       graph->addEdges(ors, or_xs);
@@ -899,7 +899,7 @@ GraphPtr SimpleGenerators::generatorEncoder(int i_bits) {
 }
 
 GraphPtr SimpleGenerators::generatorSubtractor(
-    int  i_bits,
+    int32_t  i_bits,
     bool i_overflowIn,
     bool i_overflowOut,
     bool i_sub
@@ -920,7 +920,7 @@ GraphPtr SimpleGenerators::generatorSubtractor(
   VertexPtr next_z;  // следующий заем
   VertexPtr curr_z;  // нынешний заём
 
-  for (int i = 0; i < i_bits; i++) {
+  for (int32_t i = 0; i < i_bits; i++) {
     std::string Z = std::to_string(i);          // нынешний индекс
     std::string NextZ = std::to_string(i + 1);  // следующий индекс
     std::string x       = "suba" + cond + Z;
@@ -1000,12 +1000,12 @@ GraphPtr SimpleGenerators::generatorSubtractor(
   return graph;
 }
 
-GraphPtr SimpleGenerators::generatorMultiplexer(int i_bits) {
+GraphPtr SimpleGenerators::generatorMultiplexer(int32_t i_bits) {
   GraphPtr               graph(new OrientedGraph);
   VertexPtr              output_f = graph->addOutput("f");
   std::vector<VertexPtr> inputs_x;
-  int                    k = 0;
-  for (int t = 0; t <= i_bits; t++) {
+  int32_t                    k = 0;
+  for (int32_t t = 0; t <= i_bits; t++) {
     if (i_bits - 1 >= std::pow(2, t))
       k++;
   }
@@ -1020,7 +1020,7 @@ GraphPtr SimpleGenerators::generatorMultiplexer(int i_bits) {
 
   if (i_bits > 1) {
     // механизм создания управляющих входов и их инверсий
-    for (int p = 0; p < k; p++) {
+    for (int32_t p = 0; p < k; p++) {
       S[p]   = std::to_string(p);
       Sp[p]  = graph->addInput("a" + S[p]);
       // graph->addVertex("not a" + S[p], "not", "not a" + S[p]);
@@ -1028,20 +1028,20 @@ GraphPtr SimpleGenerators::generatorMultiplexer(int i_bits) {
       graph->addEdge(Sp[p], NSp[p]);
     }
     // механизм создания входов
-    for (int i = 0; i < i_bits; i++) {
+    for (int32_t i = 0; i < i_bits; i++) {
       Z[i]  = std::to_string(i);
       Zp[i] = graph->addInput("x" + Z[i]);
       F[i]  = std::bitset<8>(i).to_string();
     }
     // механизм создания связей между входами и and
-    for (int i = 0; i < i_bits; i++) {
+    for (int32_t i = 0; i < i_bits; i++) {
       ands[i] = graph->addGate(Gates::GateAnd, "and_for_or_" + Z[i]);
       graph->addEdge(Zp[i], ands[i]);
     }
 
-    for (int i = 0; i < i_bits; i++) {
-      int len = F[i].size();
-      for (int w = 0; w < k; w++) {
+    for (int32_t i = 0; i < i_bits; i++) {
+      int32_t len = F[i].size();
+      for (int32_t w = 0; w < k; w++) {
         if (len < w + 1) {
           graph->addEdge(NSp[w], ands[i]);
         } else {
@@ -1067,7 +1067,7 @@ GraphPtr SimpleGenerators::generatorMultiplexer(int i_bits) {
   return graph;
 }
 
-GraphPtr SimpleGenerators::generatorDemultiplexer(int i_bits) {
+GraphPtr SimpleGenerators::generatorDemultiplexer(int32_t i_bits) {
   // i_bits - количество выходных сигналов, то есть количество х
   // f - значение функции на входе
   // i_outbits - количество адресных входов, то есть количество а
@@ -1084,8 +1084,8 @@ GraphPtr SimpleGenerators::generatorDemultiplexer(int i_bits) {
   GraphPtr  graph(new OrientedGraph);
   VertexPtr input_f = graph->addInput("f");
 
-  int       k       = 0;
-  for (int t = 0; t <= i_bits; t++) {
+  int32_t       k       = 0;
+  for (int32_t t = 0; t <= i_bits; t++) {
     if (i_bits - 1 >= std::pow(2, t))
       k++;
   }
@@ -1099,7 +1099,7 @@ GraphPtr SimpleGenerators::generatorDemultiplexer(int i_bits) {
   std::vector<VertexPtr>   Zp(i_bits);
 
   if (i_bits > 1) {
-    for (int p = 0; p <= k - 1; p++) {
+    for (int32_t p = 0; p <= k - 1; p++) {
       S[p]   = std::to_string(p);
       Sp[p]  = graph->addInput("a" + S[p]);
       // graph->addVertex("not a" + S[p], "not", "not a" + S[p]);
@@ -1107,21 +1107,21 @@ GraphPtr SimpleGenerators::generatorDemultiplexer(int i_bits) {
       graph->addEdge(Sp[p], NSp[p]);
     }
 
-    for (int i = 0; i <= i_bits - 1; i++) {
+    for (int32_t i = 0; i <= i_bits - 1; i++) {
       Z[i]  = std::to_string(i);
       Zp[i] = graph->addOutput("x" + Z[i]);
       F[i]  = std::bitset<8>(i).to_string();
     }
 
-    for (int i = 0; i <= i_bits - 1; i++) {
+    for (int32_t i = 0; i <= i_bits - 1; i++) {
       ands[i] = graph->addGate(Gates::GateAnd, "and_for_output_" + Z[i]);
       graph->addEdge(input_f, ands[i]);
       graph->addEdge(ands[i], Zp[i]);
     }
 
-    for (int i = 0; i <= i_bits - 1; i++) {
-      int len = F[i].size();
-      for (int w = 0; w <= k - 1; w++) {
+    for (int32_t i = 0; i <= i_bits - 1; i++) {
+      int32_t len = F[i].size();
+      for (int32_t w = 0; w <= k - 1; w++) {
         if (len < w + 1) {
           graph->addEdge(NSp[w], ands[i]);
         } else {
@@ -1139,7 +1139,7 @@ GraphPtr SimpleGenerators::generatorDemultiplexer(int i_bits) {
   return graph;
 }
 
-GraphPtr SimpleGenerators::generatorDecoder(int i_bits) {
+GraphPtr SimpleGenerators::generatorDecoder(int32_t i_bits) {
   // bits - количество входов
   // T[]- массив для текущего ряда узлов
   // X[]- массив для предыдущего ряда узлов
@@ -1150,23 +1150,23 @@ GraphPtr SimpleGenerators::generatorDecoder(int i_bits) {
     std::vector<VertexPtr> T(pow(2, i_bits));
     std::vector<VertexPtr> X(pow(2, i_bits));
     std::vector<VertexPtr> Out(pow(2, i_bits));
-    for (int i = 0; i < i_bits; i++) {
+    for (int32_t i = 0; i < i_bits; i++) {
       std::string Z = std::to_string(i);
       X[i]          = graph->addInput("x" + Z);
       X[i + i_bits] = graph->addGate(GateNot, "not (x" + Z + ")");
       graph->addEdge(X[i], X[i + i_bits]);
     }
-    for (int i = 0; i < pow(2, i_bits); i++) {
+    for (int32_t i = 0; i < pow(2, i_bits); i++) {
       std::string Z = std::to_string(i);
       Out[i]        = graph->addOutput("f" + Z);
     }
-    int p = i_bits;
-    for (int i = 0; i < pow(2, i_bits); i++) {
+    int32_t p = i_bits;
+    for (int32_t i = 0; i < pow(2, i_bits); i++) {
       T[i] = graph->addGate(GateAnd, "and" + std::to_string(i));
-      std::bitset<sizeof(int) * 8> bs(i);
+      std::bitset<sizeof(int32_t) * 8> bs(i);
       std::string                  bit_string = bs.to_string();
       std::string res = bit_string.substr(bit_string.length() - i_bits);
-      for (int j = 0; j < res.length(); j++) {
+      for (int32_t j = 0; j < res.length(); j++) {
         if (res[j] == '1') {
           graph->addEdge(X[j], T[i]);
         } else {
@@ -1174,13 +1174,13 @@ GraphPtr SimpleGenerators::generatorDecoder(int i_bits) {
         }
       }
     }
-    for (int i = 0; i < pow(2, i_bits); i++) {
+    for (int32_t i = 0; i < pow(2, i_bits); i++) {
       graph->addEdge(T[i], Out[i]);
     }
   } else {
     VertexPtr x     = graph->addInput("x");
     VertexPtr not_x = graph->addGate(GateNot, "not (x)");
-    for (int i = 0; i < 2; i++) {
+    for (int32_t i = 0; i < 2; i++) {
       VertexPtr out = graph->addOutput("f" + std::to_string(i));
       if (i == 0) {
         graph->addEdge(not_x, out);
@@ -1192,7 +1192,7 @@ GraphPtr SimpleGenerators::generatorDecoder(int i_bits) {
   return graph;
 }
 
-GraphPtr SimpleGenerators::generatorParity(int i_bits) {
+GraphPtr SimpleGenerators::generatorParity(int32_t i_bits) {
   // i_bits - количество входов
   // elem - массив для сохранения вершин
   // xors - промежуточный массив для сохранения вершин
@@ -1207,19 +1207,19 @@ GraphPtr SimpleGenerators::generatorParity(int i_bits) {
   std::vector<VertexPtr> elem(i_bits);
   std::vector<VertexPtr> xors;
 
-  for (int i = 0; i < i_bits; i++) {
+  for (int32_t i = 0; i < i_bits; i++) {
     elem[i] = graph->addInput("x" + std::to_string(i));
   }
 
-  int  k = 0;
+  int32_t  k = 0;
   bool shift;
-  int  count = i_bits;
+  int32_t  count = i_bits;
   while (count != 1) {
     count % 2 == 1 ? shift = true : shift = false;
     xors.clear();
     std::string str_k = std::to_string(k);
-    int         n     = 0;
-    for (int i = 1; i < count; i += 2) {
+    int32_t         n     = 0;
+    for (int32_t i = 1; i < count; i += 2) {
       std::string str_n = std::to_string(n);
       VertexPtr   Xor =
           graph->addGate(Gates::GateXor, "xor_" + str_k + "_" + str_n);
@@ -1237,7 +1237,7 @@ GraphPtr SimpleGenerators::generatorParity(int i_bits) {
   return graph;
 }
 
-GraphPtr SimpleGenerators::generatorMultiplier(int i_bits) {
+GraphPtr SimpleGenerators::generatorMultiplier(int32_t i_bits) {
   GraphPtr               graph(new OrientedGraph);
   VertexPtr              const_1;
 
@@ -1257,9 +1257,9 @@ GraphPtr SimpleGenerators::generatorMultiplier(int i_bits) {
   VertexPtr              m;
   // m - бит полученного умножения, выход
 
-  int                    n = 1;
+  int32_t                    n = 1;
   // n - числовой порядок выходов
-  for (int ib = 1; ib <= i_bits; ib++) {
+  for (int32_t ib = 1; ib <= i_bits; ib++) {
     std::string str_i = std::to_string(ib);
     input_xb          = graph->addInput("xb" + str_i);
     input_xa          = graph->addInput("xa" + str_i);
@@ -1273,7 +1273,7 @@ GraphPtr SimpleGenerators::generatorMultiplier(int i_bits) {
     // ABsum - получает
     // информацию о результате прошлой итерации b
 
-    for (int ia = 1; ia <= i_bits; ia++) {
+    for (int32_t ia = 1; ia <= i_bits; ia++) {
       std::string IA  = std::to_string(ia);      // IA - index a
       std::string IAN = std::to_string(ia + 1);  // IAN - index a next
 
@@ -1414,8 +1414,8 @@ GraphPtr SimpleGenerators::generatorMultiplier(int i_bits) {
 }
 
 GraphPtr SimpleGenerators::generatorALU(
-    int                  i_bits,
-    int                  i_outbits,
+    int32_t                  i_bits,
+    int32_t                  i_outbits,
     bool                 ALL,
     bool                 SUM,
     bool                 SUB,
@@ -1432,16 +1432,16 @@ GraphPtr SimpleGenerators::generatorALU(
     bool                 CNF,
     bool                 RNL,
     bool                 NUM_OP,
-    int                  minLevel,
-    int                  maxLevel,
-    int                  minElement,
-    int                  maxElement,
-    std::map<Gates, int> m,
+    uint32_t                  minLevel,
+    uint32_t                  maxLevel,
+    uint32_t                  minElement,
+    uint32_t                  maxElement,
+    std::map<Gates, int32_t> m,
     bool                 LeaveEmptyOut
 ) {
   GraphPtr  graph(new OrientedGraph);
   VertexPtr const_0 = graph->addConst('0', "const_0");
-  int       x       = 0;
+  int32_t       x       = 0;
   if (ALL) {
     SUM    = true;
     SUB    = true;
@@ -1465,7 +1465,7 @@ GraphPtr SimpleGenerators::generatorALU(
     + (CNF ? 3 : 0) + (RNL ? 1 : 0) + (NUM_OP ? 1 : 0);
 
   // размерность АЛУ (сколько генераций мультиплексоров необходимо выполнить)
-  int size = i_bits;
+  int32_t size = i_bits;
   size = MULT ? i_bits * 2 : (SUM || NSUM || SUB || NSUB ? i_bits + 1 : i_bits);
   if (CNF || RNL || NUM_OP) {
     if (MULT) {
@@ -1481,15 +1481,15 @@ GraphPtr SimpleGenerators::generatorALU(
     size = i_bits + 1;
   }
 
-  int k = 0;
-  for (int t = 0; t <= x; t++) {
+  int32_t k = 0;
+  for (int32_t t = 0; t <= x; t++) {
     if (x - 1 >= std::pow(2, t))
       k++;
   }
 
   std::vector<VertexPtr> controls(k);
 
-  for (int i = 0; i < k; i++) {
+  for (int32_t i = 0; i < k; i++) {
     std::string s = std::to_string(i);
     controls[i]   = graph->addInput("cont_ALU" + s);
   }
@@ -1499,7 +1499,7 @@ GraphPtr SimpleGenerators::generatorALU(
   std::vector<VertexPtr>              inputs_B(i_bits);
   std::vector<std::vector<VertexPtr>> outputs_gens;
 
-  for (int i = 0; i < i_bits; i++) {
+  for (int32_t i = 0; i < i_bits; i++) {
     std::string A     = std::to_string(i);
     VertexPtr   A_alu = graph->addInput("A_alu" + A);
     VertexPtr   B_alu = graph->addInput("B_alu" + A);
@@ -1513,7 +1513,7 @@ GraphPtr SimpleGenerators::generatorALU(
   std::string A;
   if (AND) {
     std::vector<VertexPtr> ands;
-    for (int i = 0; i < i_bits; i++) {
+    for (int32_t i = 0; i < i_bits; i++) {
       A                 = std::to_string(i);
       VertexPtr and_ALU = graph->addGate(Gates::GateAnd, "and_ALU" + A);
       graph->addEdges({inputs_A[i], inputs_B[i]}, and_ALU);
@@ -1523,7 +1523,7 @@ GraphPtr SimpleGenerators::generatorALU(
   }
   if (NAND) {
     std::vector<VertexPtr> nands;
-    for (int i = 0; i < i_bits; i++) {
+    for (int32_t i = 0; i < i_bits; i++) {
       A                  = std::to_string(i);
       VertexPtr nand_ALU = graph->addGate(Gates::GateNand, "nand_ALU" + A);
       graph->addEdges({inputs_A[i], inputs_B[i]}, nand_ALU);
@@ -1533,7 +1533,7 @@ GraphPtr SimpleGenerators::generatorALU(
   }
   if (OR) {
     std::vector<VertexPtr> ors;
-    for (int i = 0; i < i_bits; i++) {
+    for (int32_t i = 0; i < i_bits; i++) {
       A                = std::to_string(i);
       VertexPtr or_ALU = graph->addGate(Gates::GateOr, "or_ALU" + A);
       graph->addEdges({inputs_A[i], inputs_B[i]}, or_ALU);
@@ -1543,7 +1543,7 @@ GraphPtr SimpleGenerators::generatorALU(
   }
   if (XOR) {
     std::vector<VertexPtr> xors;
-    for (int i = 0; i < i_bits; i++) {
+    for (int32_t i = 0; i < i_bits; i++) {
       A                 = std::to_string(i);
       VertexPtr xor_ALU = graph->addGate(Gates::GateXor, "xor_ALU" + A);
       graph->addEdges({inputs_A[i], inputs_B[i]}, xor_ALU);
@@ -1553,7 +1553,7 @@ GraphPtr SimpleGenerators::generatorALU(
   }
   if (NOR) {
     std::vector<VertexPtr> nors;
-    for (int i = 0; i < i_bits; i++) {
+    for (int32_t i = 0; i < i_bits; i++) {
       A                 = std::to_string(i);
       VertexPtr nor_ALU = graph->addGate(Gates::GateNor, "nor_ALU" + A);
       graph->addEdges({inputs_A[i], inputs_B[i]}, nor_ALU);
@@ -1563,7 +1563,7 @@ GraphPtr SimpleGenerators::generatorALU(
   }
   if (XNOR) {
     std::vector<VertexPtr> xnors;
-    for (int i = 0; i < i_bits; i++) {
+    for (int32_t i = 0; i < i_bits; i++) {
       A                  = std::to_string(i);
       VertexPtr xnor_ALU = graph->addGate(Gates::GateXnor, "xnor_ALU" + A);
       graph->addEdges({inputs_A[i], inputs_B[i]}, xnor_ALU);
@@ -1742,13 +1742,13 @@ GraphPtr SimpleGenerators::generatorALU(
     outputs_gens.push_back(output_num_op);
   }
 
-  int max = 0;
-  for (int i = 0; i < outputs_gens.size(); i++) {
+  size_t max = 0;
+  for (size_t i = 0; i < outputs_gens.size(); i++) {
     if (outputs_gens[i].size() > max) {
       max = outputs_gens[i].size();
     }
   }
-  for (int i = 0; i < outputs_gens.size(); i++) {
+  for (size_t i = 0; i < outputs_gens.size(); i++) {
     if (outputs_gens[i].size() < max) {
       outputs_gens[i].resize(max, const_0);
     }
@@ -1758,7 +1758,7 @@ GraphPtr SimpleGenerators::generatorALU(
       AuxMethods::transpose(outputs_gens);
   std::vector<VertexPtr> outputs_alu;
 
-  for (int i = 0; i < inputs_alu.size(); i++) {
+  for (size_t i = 0; i < inputs_alu.size(); i++) {
     inputs_alu[i].insert(
         inputs_alu[i].begin(), controls.begin(), controls.end()
     );
@@ -1770,7 +1770,7 @@ GraphPtr SimpleGenerators::generatorALU(
     outputs_alu.push_back(graph->addSubGraph(mult, vertices).back());
   }
 
-  for (int i = 0; i < outputs_alu.size(); i++) {
+  for (size_t i = 0; i < outputs_alu.size(); i++) {
     VertexPtr out_ALU = graph->addOutput("out_ALU" + std::to_string(i));
     graph->addEdge(outputs_alu[i], out_ALU);
   }

--- a/src/generators/simple/SimpleGenerators.cpp
+++ b/src/generators/simple/SimpleGenerators.cpp
@@ -51,7 +51,8 @@ int32_t SimpleGenerators::getRangomXnorNumber() {
   )];
 }
 
-std::pair<Gates, int32_t> SimpleGenerators::getRandomElement(const GatesInfo& i_info
+std::pair<Gates, int32_t> SimpleGenerators::getRandomElement(
+    const GatesInfo& i_info
 ) {
   // rand element of map
   auto val = i_info.begin();
@@ -63,7 +64,8 @@ std::pair<Gates, int32_t> SimpleGenerators::getRandomElement(const GatesInfo& i_
   );
 }
 
-std::pair<Gates, int32_t> SimpleGenerators::getRandomElement(u_int32_t i_gatesLimit
+std::pair<Gates, int32_t> SimpleGenerators::getRandomElement(
+    u_int32_t i_gatesLimit
 ) {
   if (i_gatesLimit >= d_maxGateNumber)
     return getRandomElement(d_gatesInputsInfo);
@@ -73,7 +75,7 @@ std::pair<Gates, int32_t> SimpleGenerators::getRandomElement(u_int32_t i_gatesLi
         d_randGenerator.getRandInt(0, 2) ? Gates::GateNot : Gates::GateBuf, 1
     );
 
-  GatesInfo        info;
+  GatesInfo            info;
   std::vector<int32_t> subval;
 
   for (auto [key, value] : d_gatesInputsInfo) {
@@ -125,8 +127,8 @@ GraphPtr
 
   for (size_t j = 0; j < i_table.getOutput(); ++j) {
     VertexPtr out = graph->addOutput("f" + std::to_string(j));
-    int32_t       mem = 0;
-    int32_t       tmp = 0;
+    int32_t   mem = 0;
+    int32_t   tmp = 0;
 
     for (int32_t i = 0; i < i_table.size(); ++i) {
       if (!(i_table.getOutTable(i, j) ^ i_tp))
@@ -199,8 +201,8 @@ GraphPtr
 }
 
 GraphPtr SimpleGenerators::zhegalkinFromTruthTable(const TruthTable& i_table) {
-  int32_t                    num_inputs  = i_table.getInput();
-  int32_t                    num_outputs = i_table.getOutput();
+  int32_t                num_inputs  = i_table.getInput();
+  int32_t                num_outputs = i_table.getOutput();
 
   GraphPtr               graph(new OrientedGraph());
   std::vector<VertexPtr> inputs;
@@ -213,7 +215,7 @@ GraphPtr SimpleGenerators::zhegalkinFromTruthTable(const TruthTable& i_table) {
   for (int32_t j = 0; j < num_outputs; ++j) {
     VertexPtr out = graph->addOutput("f" + std::to_string(j));
 
-    int32_t       mem = 0;
+    int32_t   mem = 0;
     for (int32_t i = 0; i < i_table.size(); ++i) {
       mem += i_table.getOutTable(i, j);
     }
@@ -288,10 +290,10 @@ GraphPtr SimpleGenerators::generatorRandLevel(
 
   // maxLevel++ // what?
 
-  int32_t         choice;
+  int32_t     choice;
   std::string expr;
   GraphPtr    graph(new OrientedGraph);
-  int32_t         child1, child2;
+  int32_t     child1, child2;
 
   for (int32_t i = 0; i < i_inputs; ++i) {
     expr = "x" + std::to_string(i);
@@ -392,8 +394,8 @@ GraphPtr SimpleGenerators::generatorRandLevelExperimental(
   // TODO what if we will need to use n-gate elements, should we add consts
   // usage?
 
-  int32_t       currIndex = i_inputs;
-  int32_t       curLen    = 0;
+  int32_t   currIndex = i_inputs;
+  int32_t   curLen    = 0;
   // we need lowest border as d_maxGateNumber, and if it is possible,
   // we set it (it changes speed of generation)
   u_int32_t c_max     = i_maxElements > d_maxGateNumber
@@ -402,9 +404,10 @@ GraphPtr SimpleGenerators::generatorRandLevelExperimental(
 
   for (int32_t i = 1; i < maxLevel; ++i) {
     // how many elements would be at this level
-    int32_t                        elemLevel = i_maxElements > 1
-                                             ? d_randGenerator.getRandInt(c_max, i_maxElements, true)
-                                             : i_maxElements;
+    int32_t elemLevel =
+        i_maxElements > 1
+            ? d_randGenerator.getRandInt(c_max, i_maxElements, true)
+            : i_maxElements;
 
     // write allowed gates to be used as parent
     std::vector<VertexPtrWeak> futureGates;
@@ -416,14 +419,14 @@ GraphPtr SimpleGenerators::generatorRandLevelExperimental(
       // from which element we should start shuffle
       // like we do not shuffle whole list, if it is possible
       // but only it's part
-      int32_t fromWhichShuffle          = d_randGenerator.getRandInt(
+      int32_t fromWhichShuffle      = d_randGenerator.getRandInt(
           0, std::max(1, (int32_t)curGates.size() - gatesNumber)
       );
       // shuffle curGates
       for (int32_t k       = fromWhichShuffle,
-               stopVal = std::min(
-                   fromWhichShuffle + gatesNumber, (int32_t)curGates.size()
-               );
+                   stopVal = std::min(
+                       fromWhichShuffle + gatesNumber, (int32_t)curGates.size()
+                   );
            k < stopVal;
            ++k) {
         std::swap(
@@ -507,16 +510,16 @@ GraphPtr SimpleGenerators::generatorRandLevelExperimental(
 }
 
 GraphPtr SimpleGenerators::generatorNumOperation(
-    uint32_t                  i_input,
-    uint32_t                  i_output,
+    uint32_t                 i_input,
+    uint32_t                 i_output,
     std::map<Gates, int32_t> i_logicOper,
-    bool                 i_leaveEmptyOut
+    bool                     i_leaveEmptyOut
 ) {
-  int32_t                              sumOper = 0, maxLvl;
+  int32_t                          sumOper = 0, maxLvl;
   std::string                      name;
   VertexPtr                        name_ptr;
-  std::map<Gates, int32_t>             copyLogicOper;
-  std::map<std::string, int32_t>       levelName;
+  std::map<Gates, int32_t>         copyLogicOper;
+  std::map<std::string, int32_t>   levelName;
   std::map<std::string, VertexPtr> levelNamePtr;
   std::vector<VertexPtr>           nameOut, nameInput;
 
@@ -630,10 +633,10 @@ std::map<Gates, int32_t> SimpleGenerators::delNull(
 }
 
 GraphPtr SimpleGenerators::generatorSummator(
-    uint32_t  i_bits,
-    bool i_overflowIn,
-    bool i_overflowOut,
-    bool i_minus
+    uint32_t i_bits,
+    bool     i_overflowIn,
+    bool     i_overflowOut,
+    bool     i_minus
 ) {
   GraphPtr    graph(new OrientedGraph);
   std::string str_x;
@@ -722,10 +725,10 @@ GraphPtr SimpleGenerators::generatorSummator(
 }
 
 GraphPtr SimpleGenerators::generatorComparison(
-    uint32_t  i_bits,
-    bool compare0,
-    bool compare1,
-    bool compare2
+    uint32_t i_bits,
+    bool     compare0,
+    bool     compare1,
+    bool     compare2
 ) {
   GraphPtr    graph(new OrientedGraph);
   VertexPtr   prev_pn_;
@@ -843,9 +846,9 @@ GraphPtr SimpleGenerators::generatorEncoder(uint32_t i_bits) {
       not_x[i] = nx;
     }
 
-    int32_t  shift = 1;
-    int32_t  count = 0;
-    bool check = false;
+    int32_t shift = 1;
+    int32_t count = 0;
+    bool    check = false;
     for (int32_t i = 0; i < pow(2, i_outbits); i++) {
       VertexPtr and_xs =
           graph->addGate(Gates::GateAnd, "and_for_or" + std::to_string(i + 1));
@@ -899,10 +902,10 @@ GraphPtr SimpleGenerators::generatorEncoder(uint32_t i_bits) {
 }
 
 GraphPtr SimpleGenerators::generatorSubtractor(
-    uint32_t  i_bits,
-    bool i_overflowIn,
-    bool i_overflowOut,
-    bool i_sub
+    uint32_t i_bits,
+    bool     i_overflowIn,
+    bool     i_overflowOut,
+    bool     i_sub
 ) {
   GraphPtr    graph(new OrientedGraph);
   VertexPtr   const_1;
@@ -1004,7 +1007,7 @@ GraphPtr SimpleGenerators::generatorMultiplexer(uint32_t i_bits) {
   GraphPtr               graph(new OrientedGraph);
   VertexPtr              output_f = graph->addOutput("f");
   std::vector<VertexPtr> inputs_x;
-  int32_t                    k = 0;
+  int32_t                k = 0;
   for (uint32_t t = 0; t <= i_bits; t++) {
     if (i_bits - 1 >= std::pow(2, t))
       k++;
@@ -1084,7 +1087,7 @@ GraphPtr SimpleGenerators::generatorDemultiplexer(uint32_t i_bits) {
   GraphPtr  graph(new OrientedGraph);
   VertexPtr input_f = graph->addInput("f");
 
-  int32_t       k       = 0;
+  int32_t   k       = 0;
   for (uint32_t t = 0; t <= i_bits; t++) {
     if (i_bits - 1 >= std::pow(2, t))
       k++;
@@ -1164,7 +1167,7 @@ GraphPtr SimpleGenerators::generatorDecoder(uint32_t i_bits) {
     for (int32_t i = 0; i < pow(2, i_bits); i++) {
       T[i] = graph->addGate(GateAnd, "and" + std::to_string(i));
       std::bitset<sizeof(int32_t) * 8> bs(i);
-      std::string                  bit_string = bs.to_string();
+      std::string                      bit_string = bs.to_string();
       std::string res = bit_string.substr(bit_string.length() - i_bits);
       for (int32_t j = 0; j < res.length(); j++) {
         if (res[j] == '1') {
@@ -1211,14 +1214,14 @@ GraphPtr SimpleGenerators::generatorParity(uint32_t i_bits) {
     elem[i] = graph->addInput("x" + std::to_string(i));
   }
 
-  int32_t  k = 0;
-  bool shift;
-  int32_t  count = i_bits;
+  int32_t k = 0;
+  bool    shift;
+  int32_t count = i_bits;
   while (count != 1) {
     count % 2 == 1 ? shift = true : shift = false;
     xors.clear();
     std::string str_k = std::to_string(k);
-    int32_t         n     = 0;
+    int32_t     n     = 0;
     for (int32_t i = 1; i < count; i += 2) {
       std::string str_n = std::to_string(n);
       VertexPtr   Xor =
@@ -1257,7 +1260,7 @@ GraphPtr SimpleGenerators::generatorMultiplier(uint32_t i_bits) {
   VertexPtr              m;
   // m - бит полученного умножения, выход
 
-  int32_t                    n = 1;
+  int32_t                n = 1;
   // n - числовой порядок выходов
   for (int32_t ib = 1; ib <= i_bits; ib++) {
     std::string str_i = std::to_string(ib);
@@ -1416,32 +1419,32 @@ GraphPtr SimpleGenerators::generatorMultiplier(uint32_t i_bits) {
 GraphPtr SimpleGenerators::generatorALU(
     int32_t                  i_bits,
     int32_t                  i_outbits,
-    bool                 ALL,
-    bool                 SUM,
-    bool                 SUB,
-    bool                 NSUM,
-    bool                 NSUB,
-    bool                 MULT,
-    bool                 COM,
-    bool                 AND,
-    bool                 NAND,
-    bool                 OR,
-    bool                 NOR,
-    bool                 XOR,
-    bool                 XNOR,
-    bool                 CNF,
-    bool                 RNL,
-    bool                 NUM_OP,
-    uint32_t                  minLevel,
-    uint32_t                  maxLevel,
-    uint32_t                  minElement,
-    uint32_t                  maxElement,
+    bool                     ALL,
+    bool                     SUM,
+    bool                     SUB,
+    bool                     NSUM,
+    bool                     NSUB,
+    bool                     MULT,
+    bool                     COM,
+    bool                     AND,
+    bool                     NAND,
+    bool                     OR,
+    bool                     NOR,
+    bool                     XOR,
+    bool                     XNOR,
+    bool                     CNF,
+    bool                     RNL,
+    bool                     NUM_OP,
+    uint32_t                 minLevel,
+    uint32_t                 maxLevel,
+    uint32_t                 minElement,
+    uint32_t                 maxElement,
     std::map<Gates, int32_t> m,
-    bool                 LeaveEmptyOut
+    bool                     LeaveEmptyOut
 ) {
   GraphPtr  graph(new OrientedGraph);
   VertexPtr const_0 = graph->addConst('0', "const_0");
-  int32_t       x       = 0;
+  int32_t   x       = 0;
   if (ALL) {
     SUM    = true;
     SUB    = true;

--- a/src/generators/simple/SimpleGenerators.hpp
+++ b/src/generators/simple/SimpleGenerators.hpp
@@ -17,7 +17,7 @@
 /// generatorComparison and generatorEncoder
 ///
 
-using GatesInfo = std::map<Gates, std::vector<int>>;
+using GatesInfo = std::map<Gates, std::vector<int32_t>>;
 
 namespace {
 /// @addtogroup UnnamedNamespaces
@@ -28,14 +28,14 @@ namespace {
 /// @tparam T The type of the map keys
 /// @param i_map The map whose maximum value is to be found
 /// @return The maximum value in the map. If the map is empty, returns -1
-/// @note The function assumes that the map values are of type int
+/// @note The function assumes that the map values are of type int32_t
 /// @}
 template<typename T>
-int maxValueInMap(const std::map<T, int>& i_map) {
+int32_t maxValueInMap(const std::map<T, int32_t>& i_map) {
   if (i_map.size() == 0) {
     return -1;
   }
-  int res = (*i_map.begin()).second;
+  int32_t res = (*i_map.begin()).second;
 
   for (const auto& [key, value] : i_map) {
     res = std::max(res, value);
@@ -51,7 +51,7 @@ int maxValueInMap(const std::map<T, int>& i_map) {
 /// singleton and is used to store settings associated with the vertices of the
 /// graph.
 /// @param d_gatesInputsInfo The data structure represented as a display
-/// (std::map<std::string, std::vector<int>>), where the keys are strings (names
+/// (std::map<std::string, std::vector<int32_t>>), where the keys are strings (names
 /// of logical operations), and the values are vectors of integers representing
 /// information about the inputs (indexes) of gates associated with each logical
 /// operation. This is a general description***
@@ -63,7 +63,7 @@ int maxValueInMap(const std::map<T, int>& i_map) {
 /// */
 
 class SimpleGenerators {
-  using GatesInfo = std::map<Gates, std::vector<int>>;
+  using GatesInfo = std::map<Gates, std::vector<int32_t>>;
 
 public:
   SimpleGenerators();
@@ -123,12 +123,12 @@ public:
   /// @param i_outputs The number of exits from the graph
 
   GraphPtr generatorRandLevel(
-      int i_minLevel,
-      int i_maxLevel,
-      int i_minElements,
-      int i_maxElements,
-      int i_inputs,
-      int i_outputs
+      uint32_t i_minLevel,
+      uint32_t i_maxLevel,
+      uint32_t i_minElements,
+      uint32_t i_maxElements,
+      uint32_t i_inputs,
+      uint32_t i_outputs
   );
 
   /// @brief generatorRandLevelExperimental The method generates a random level
@@ -166,12 +166,12 @@ public:
   /// the method throws an exception std::invalid_argument.
 
   GraphPtr generatorRandLevelExperimental(
-      u_int32_t i_minLevel,
-      u_int32_t i_maxLevel,
-      u_int32_t i_minElements,
-      u_int32_t i_maxElements,
-      u_int32_t i_inputs,
-      u_int32_t i_outputs
+      uint32_t i_minLevel,
+      uint32_t i_maxLevel,
+      uint32_t i_minElements,
+      uint32_t i_maxElements,
+      uint32_t i_inputs,
+      uint32_t i_outputs
   );
 
   /// @todo: Description algorithm
@@ -188,9 +188,9 @@ public:
   /// @return the created OrientedGraph
 
   GraphPtr generatorNumOperation(
-      int                  i_input,
-      int                  i_output,
-      std::map<Gates, int> i_logicOper,
+      uint32_t                  i_input,
+      uint32_t                  i_output,
+      std::map<Gates, int32_t> i_logicOper,
       bool                 i_leaveEmptyOut = true
   );
 
@@ -213,7 +213,7 @@ public:
   /// @return the created OrientedGraph
 
   GraphPtr generatorSummator(
-      int  i_bits,
+      uint32_t  i_bits,
       bool i_overflowIn,
       bool i_overflowOut,
       bool i_minus
@@ -239,7 +239,7 @@ public:
   /// @return the created OrientedGraph
 
   GraphPtr generatorComparison(
-      int  i_bits,
+      uint32_t  i_bits,
       bool compare0,
       bool compare1,
       bool compare2
@@ -256,7 +256,7 @@ public:
   /// (variables) in the graph.
   /// @return the created OrientedGraph
 
-  GraphPtr generatorEncoder(int i_bits);
+  GraphPtr generatorEncoder(uint32_t i_bits);
 
   /// @brief generatorSubtractor represents the generation of a combinational
   /// subtractor scheme. It is based on the arithmetic difference operation,
@@ -278,7 +278,7 @@ public:
   /// @return the created OrientedGraph
 
   GraphPtr generatorSubtractor(
-      int  i_bits,
+      uint32_t  i_bits,
       bool i_overflowIn,
       bool i_overflowOut,
       bool i_sub
@@ -295,7 +295,7 @@ public:
   /// (variables) in the graph.
   /// @return the created OrientedGraph
 
-  GraphPtr generatorMultiplexer(int i_bits);
+  GraphPtr generatorMultiplexer(uint32_t i_bits);
 
   /// @brief generatorDemultiplexer represents the generation of the
   /// combinational circuit of the demultiplexer. The generation logic almost
@@ -306,7 +306,7 @@ public:
   /// (variables) in the graph.
   /// @return the created OrientedGraph
 
-  GraphPtr generatorDemultiplexer(int i_bits);
+  GraphPtr generatorDemultiplexer(uint32_t i_bits);
 
   /// @brief generatorDecoder represents the generation of a combinational
   /// decoder circuit. The logic of generation is close to the logic of
@@ -318,7 +318,7 @@ public:
   /// (variables) in the graph.
   /// @return the created OrientedGraph
 
-  GraphPtr generatorDecoder(int i_bits);
+  GraphPtr generatorDecoder(uint32_t i_bits);
 
   /// @brief generatorParity represents the generation of a combinational parity
   /// check scheme. The graph is based on the logical XOR operation, which is
@@ -329,7 +329,7 @@ public:
   /// (variables) in the graph.
   /// @return the created OrientedGraph
 
-  GraphPtr generatorParity(int i_bits);
+  GraphPtr generatorParity(uint32_t i_bits);
 
   /// @brief generatorMultiplier represents the generation of a combinational
   /// multiplier circuit. It is based on the arithmetic multiplication operation
@@ -343,7 +343,7 @@ public:
   /// (variables) in the graph.
   /// @return the created OrientedGraph
 
-  GraphPtr generatorMultiplier(int i_bits);
+  GraphPtr generatorMultiplier(uint32_t i_bits);
 
   /// @brief generatorALU represents the generation of a combinational circuit
   /// of an ALU (Arithmetic Logic Unit). It is a multi-structured graph
@@ -447,7 +447,7 @@ public:
   /// @code
   /// SimpleGenerators generators;
   /// // Define input information for logic gates
-  /// std::map<std::string, std::vector<int>> gateInputsInfo =
+  /// std::map<std::string, std::vector<int32_t>> gateInputsInfo =
   /// {
   /// {"AND", {2, 3}},
   /// {"OR", {2, 3}},
@@ -458,7 +458,7 @@ public:
   /// generators.setGatesInputsInfo(gateInputsInfo);
   /// @endcode
 
-  void setGatesInputsInfo(const std::map<std::string, std::vector<int>>& i_info
+  void setGatesInputsInfo(const std::map<std::string, std::vector<int32_t>>& i_info
   ) {
     d_minGateNumber = INT_MAX;
 
@@ -481,11 +481,11 @@ public:
 
 private:
   std::shared_ptr<Settings> d_settings = Settings::getInstance("GraphVertex");
-  std::map<Gates, int>      delNull(std::map<Gates, int> i_copyLogicOper);
+  std::map<Gates, int32_t>      delNull(std::map<Gates, int32_t> i_copyLogicOper);
 
   // moved it here, because we need to use templates
   template<typename T>
-  T randomGenerator(const std::map<T, int>& i_map) {
+  T randomGenerator(const std::map<T, int32_t>& i_map) {
     // rand element of map
     auto val = i_map.begin();
     std::advance(val, d_randGenerator.getRandInt(0, i_map.size()));
@@ -493,8 +493,8 @@ private:
     return val->first;
   }
 
-  std::pair<Gates, int>   getRandomElement(const GatesInfo& i_info);
-  std::pair<Gates, int>   getRandomElement(u_int32_t i_gatesLimit);
+  std::pair<Gates, int32_t>   getRandomElement(const GatesInfo& i_info);
+  std::pair<Gates, int32_t>   getRandomElement(u_int32_t i_gatesLimit);
 
   /// @brief getRangomAndNumber The getRangomAndNumber method returns a random
   /// value from the list of possible input ports for the "AND" operator.
@@ -502,7 +502,7 @@ private:
   /// operator.
   /// */
 
-  int                     getRangomAndNumber();
+  int32_t                     getRangomAndNumber();
 
   /// @brief getRangomOrNumber method is a random value from the list of
   /// possible input ports for the "OR" operator
@@ -510,7 +510,7 @@ private:
   /// operator.
   /// */
 
-  int                     getRangomOrNumber();
+  int32_t                     getRangomOrNumber();
 
   /// @brief getRangomNandNumber The method returns a random value from the list
   /// of possible input ports for the "NAND" operator.
@@ -518,7 +518,7 @@ private:
   /// operator
   /// */
 
-  int                     getRangomNandNumber();
+  int32_t                     getRangomNandNumber();
 
   /// @brief getRangomNorNumber The method returns a random value from the list
   /// of possible input ports for the "NOR" operator.
@@ -526,7 +526,7 @@ private:
   /// operator
   /// */
 
-  int                     getRangomNorNumber();
+  int32_t                     getRangomNorNumber();
 
   /// @brief getRangomXorNumber The method returns a random value from the list
   /// of possible input ports for the "XOR" operator.
@@ -534,7 +534,7 @@ private:
   /// operator.
   /// */
 
-  int                     getRangomXorNumber();
+  int32_t                     getRangomXorNumber();
 
   /// @brief The method returns a random value from the list of possible input
   /// ports for the "XNOR" operator.
@@ -542,10 +542,10 @@ private:
   /// operator
   /// */
 
-  int                     getRangomXnorNumber();
+  int32_t                     getRangomXnorNumber();
 
   GatesInfo               d_gatesInputsInfo;
   RandomGeneratorWithSeed d_randGenerator;
-  int                     d_maxGateNumber = 0;
-  int                     d_minGateNumber = 0;
+  int32_t                     d_maxGateNumber = 0;
+  int32_t                     d_minGateNumber = 0;
 };

--- a/src/generators/simple/SimpleGenerators.hpp
+++ b/src/generators/simple/SimpleGenerators.hpp
@@ -67,7 +67,7 @@ class SimpleGenerators {
 
 public:
   SimpleGenerators();
-  SimpleGenerators(int i_seed);
+  SimpleGenerators(uint_fast32_t i_seed);
 
   SimpleGenerators(const SimpleGenerators& other)            = delete;
   SimpleGenerators& operator=(const SimpleGenerators& other) = delete;
@@ -411,8 +411,8 @@ public:
   /// @return the created OrientedGraph
 
   GraphPtr generatorALU(
-      int                  i_bits,
-      int                  i_outbits,
+      int32_t                  i_bits,
+      int32_t                  i_outbits,
       bool                 ALL,
       bool                 SUM,
       bool                 SUB,
@@ -429,11 +429,11 @@ public:
       bool                 CNF,
       bool                 RNL,
       bool                 NUM_OP,
-      int                  minLevel,
-      int                  maxLevel,
-      int                  minElement,
-      int                  maxElement,
-      std::map<Gates, int> m,
+      uint32_t                  minLevel,
+      uint32_t                  maxLevel,
+      uint32_t                  minElement,
+      uint32_t                  maxElement,
+      std::map<Gates, int32_t> m,
       bool                 LeaveEmptyOut
   );
 

--- a/src/generators/simple/SimpleGenerators.hpp
+++ b/src/generators/simple/SimpleGenerators.hpp
@@ -495,7 +495,7 @@ private:
   }
 
   std::pair<Gates, int32_t> getRandomElement(const GatesInfo& i_info);
-  std::pair<Gates, int32_t> getRandomElement(u_int32_t i_gatesLimit);
+  std::pair<Gates, int32_t> getRandomElement(uint32_t i_gatesLimit);
 
   /// @brief getRangomAndNumber The getRangomAndNumber method returns a random
   /// value from the list of possible input ports for the "AND" operator.

--- a/src/generators/simple/SimpleGenerators.hpp
+++ b/src/generators/simple/SimpleGenerators.hpp
@@ -51,10 +51,10 @@ int32_t maxValueInMap(const std::map<T, int32_t>& i_map) {
 /// singleton and is used to store settings associated with the vertices of the
 /// graph.
 /// @param d_gatesInputsInfo The data structure represented as a display
-/// (std::map<std::string, std::vector<int32_t>>), where the keys are strings (names
-/// of logical operations), and the values are vectors of integers representing
-/// information about the inputs (indexes) of gates associated with each logical
-/// operation. This is a general description***
+/// (std::map<std::string, std::vector<int32_t>>), where the keys are strings
+/// (names of logical operations), and the values are vectors of integers
+/// representing information about the inputs (indexes) of gates associated with
+/// each logical operation. This is a general description***
 /// @param d_randGenerator An object of the Random Generator With Seed class,
 /// which is used to generate random numbers based on a given grain (seed).
 /// @param d_maxGateNumber An integer value representing the maximum gate number
@@ -188,10 +188,10 @@ public:
   /// @return the created OrientedGraph
 
   GraphPtr generatorNumOperation(
-      uint32_t                  i_input,
-      uint32_t                  i_output,
+      uint32_t                 i_input,
+      uint32_t                 i_output,
       std::map<Gates, int32_t> i_logicOper,
-      bool                 i_leaveEmptyOut = true
+      bool                     i_leaveEmptyOut = true
   );
 
   /// @brief generatorSummator represents the generation of a combinational
@@ -213,10 +213,10 @@ public:
   /// @return the created OrientedGraph
 
   GraphPtr generatorSummator(
-      uint32_t  i_bits,
-      bool i_overflowIn,
-      bool i_overflowOut,
-      bool i_minus
+      uint32_t i_bits,
+      bool     i_overflowIn,
+      bool     i_overflowOut,
+      bool     i_minus
   );
 
   /// @brief generatorComparison represents the generation of a combinational
@@ -239,10 +239,10 @@ public:
   /// @return the created OrientedGraph
 
   GraphPtr generatorComparison(
-      uint32_t  i_bits,
-      bool compare0,
-      bool compare1,
-      bool compare2
+      uint32_t i_bits,
+      bool     compare0,
+      bool     compare1,
+      bool     compare2
   );
 
   /// @brief generatorEncoder represents the generation of a combinational
@@ -278,10 +278,10 @@ public:
   /// @return the created OrientedGraph
 
   GraphPtr generatorSubtractor(
-      uint32_t  i_bits,
-      bool i_overflowIn,
-      bool i_overflowOut,
-      bool i_sub
+      uint32_t i_bits,
+      bool     i_overflowIn,
+      bool     i_overflowOut,
+      bool     i_sub
   );
 
   /// @brief generatorMultiplexer represents the generation of a combinational
@@ -413,28 +413,28 @@ public:
   GraphPtr generatorALU(
       int32_t                  i_bits,
       int32_t                  i_outbits,
-      bool                 ALL,
-      bool                 SUM,
-      bool                 SUB,
-      bool                 NSUM,
-      bool                 NSUB,
-      bool                 MULT,
-      bool                 COM,
-      bool                 AND,
-      bool                 NAND,
-      bool                 OR,
-      bool                 NOR,
-      bool                 XOR,
-      bool                 XNOR,
-      bool                 CNF,
-      bool                 RNL,
-      bool                 NUM_OP,
-      uint32_t                  minLevel,
-      uint32_t                  maxLevel,
-      uint32_t                  minElement,
-      uint32_t                  maxElement,
+      bool                     ALL,
+      bool                     SUM,
+      bool                     SUB,
+      bool                     NSUM,
+      bool                     NSUB,
+      bool                     MULT,
+      bool                     COM,
+      bool                     AND,
+      bool                     NAND,
+      bool                     OR,
+      bool                     NOR,
+      bool                     XOR,
+      bool                     XNOR,
+      bool                     CNF,
+      bool                     RNL,
+      bool                     NUM_OP,
+      uint32_t                 minLevel,
+      uint32_t                 maxLevel,
+      uint32_t                 minElement,
+      uint32_t                 maxElement,
       std::map<Gates, int32_t> m,
-      bool                 LeaveEmptyOut
+      bool                     LeaveEmptyOut
   );
 
   /// @brief setGatesInputsInfo It is designed to set information about the
@@ -458,7 +458,8 @@ public:
   /// generators.setGatesInputsInfo(gateInputsInfo);
   /// @endcode
 
-  void setGatesInputsInfo(const std::map<std::string, std::vector<int32_t>>& i_info
+  void setGatesInputsInfo(
+      const std::map<std::string, std::vector<int32_t>>& i_info
   ) {
     d_minGateNumber = INT_MAX;
 
@@ -481,7 +482,7 @@ public:
 
 private:
   std::shared_ptr<Settings> d_settings = Settings::getInstance("GraphVertex");
-  std::map<Gates, int32_t>      delNull(std::map<Gates, int32_t> i_copyLogicOper);
+  std::map<Gates, int32_t>  delNull(std::map<Gates, int32_t> i_copyLogicOper);
 
   // moved it here, because we need to use templates
   template<typename T>
@@ -493,8 +494,8 @@ private:
     return val->first;
   }
 
-  std::pair<Gates, int32_t>   getRandomElement(const GatesInfo& i_info);
-  std::pair<Gates, int32_t>   getRandomElement(u_int32_t i_gatesLimit);
+  std::pair<Gates, int32_t> getRandomElement(const GatesInfo& i_info);
+  std::pair<Gates, int32_t> getRandomElement(u_int32_t i_gatesLimit);
 
   /// @brief getRangomAndNumber The getRangomAndNumber method returns a random
   /// value from the list of possible input ports for the "AND" operator.
@@ -502,7 +503,7 @@ private:
   /// operator.
   /// */
 
-  int32_t                     getRangomAndNumber();
+  int32_t                   getRangomAndNumber();
 
   /// @brief getRangomOrNumber method is a random value from the list of
   /// possible input ports for the "OR" operator
@@ -510,7 +511,7 @@ private:
   /// operator.
   /// */
 
-  int32_t                     getRangomOrNumber();
+  int32_t                   getRangomOrNumber();
 
   /// @brief getRangomNandNumber The method returns a random value from the list
   /// of possible input ports for the "NAND" operator.
@@ -518,7 +519,7 @@ private:
   /// operator
   /// */
 
-  int32_t                     getRangomNandNumber();
+  int32_t                   getRangomNandNumber();
 
   /// @brief getRangomNorNumber The method returns a random value from the list
   /// of possible input ports for the "NOR" operator.
@@ -526,7 +527,7 @@ private:
   /// operator
   /// */
 
-  int32_t                     getRangomNorNumber();
+  int32_t                   getRangomNorNumber();
 
   /// @brief getRangomXorNumber The method returns a random value from the list
   /// of possible input ports for the "XOR" operator.
@@ -534,7 +535,7 @@ private:
   /// operator.
   /// */
 
-  int32_t                     getRangomXorNumber();
+  int32_t                   getRangomXorNumber();
 
   /// @brief The method returns a random value from the list of possible input
   /// ports for the "XNOR" operator.
@@ -542,10 +543,10 @@ private:
   /// operator
   /// */
 
-  int32_t                     getRangomXnorNumber();
+  int32_t                   getRangomXnorNumber();
 
-  GatesInfo               d_gatesInputsInfo;
-  RandomGeneratorWithSeed d_randGenerator;
-  int32_t                     d_maxGateNumber = 0;
-  int32_t                     d_minGateNumber = 0;
+  GatesInfo                 d_gatesInputsInfo;
+  RandomGeneratorWithSeed   d_randGenerator;
+  int32_t                   d_maxGateNumber = 0;
+  int32_t                   d_minGateNumber = 0;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,9 +21,9 @@ int main(int argc, char **argv) {
   const char *const short_opts = "j:n:";
   const option long_opts[] = {{"json_path", required_argument, nullptr, 'j'},
                               {"num_nodes", required_argument, nullptr, 'n'}};
-  int c;
+  int32_t c;
 
-  int opt;
+  int32_t opt;
   while ((opt = getopt_long(argc, argv, short_opts, long_opts, nullptr)) !=
          -1) {
     switch (opt) {

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -22,7 +22,7 @@ std::shared_ptr<Settings> Settings::getInstance(const std::string& i_value) {
 
 void Settings::loadSettings() {
   for (const auto& [key, value] : d_logicOperations) {
-    int i = value.second;
+    int32_t i = value.second;
     if (!d_operationsToHierarchy.count(i))
       d_operationsToHierarchy[i] = {};
     d_operationsToHierarchy[i].push_back(value.first);
@@ -36,9 +36,9 @@ void Settings::loadSettings() {
 
     readFile >> d_csvdataset >> d_fileName >> d_datasetPath >> d_pathToNadezhda;
 
-    int nadezhdaPathsCount;
+    uint32_t nadezhdaPathsCount;
     readFile >> nadezhdaPathsCount;
-    for (int i = 0; i < nadezhdaPathsCount; ++i) {
+    for (uint32_t i = 0; i < nadezhdaPathsCount; ++i) {
       std::string tool, path;
       readFile >> tool >> path;
       d_nadezhda[tool] = path;
@@ -46,9 +46,9 @@ void Settings::loadSettings() {
 
     readFile >> d_numThreads;
 
-    int logicOperationCount;
+    uint32_t logicOperationCount;
     readFile >> logicOperationCount;
-    for (int i = 0; i < logicOperationCount; ++i) {
+    for (uint32_t i = 0; i < logicOperationCount; ++i) {
       std::string operation, operationName, operationId;
       readFile >> operation;  // When it comes to input    there have to be
                               // empty string at operationName,    so it is
@@ -64,15 +64,15 @@ void Settings::loadSettings() {
       d_logicOperations[operation] = {operationName, std::stoi(operationId)};
     }
 
-    int operationHierarchyCount;
+    int32_t operationHierarchyCount;
     readFile >> operationHierarchyCount;
-    for (int i = 0; i < operationHierarchyCount; ++i) {
-      int                      operationId, operationHierarchyCount;
+    for (int32_t i = 0; i < operationHierarchyCount; ++i) {
+      int32_t                      operationId, operationHierarchyCount;
       std::vector<std::string> operations;
       readFile >> operationId >> operationHierarchyCount;
 
       std::string operation;
-      for (int j = 0; j < operationHierarchyCount; ++j) {
+      for (int32_t j = 0; j < operationHierarchyCount; ++j) {
         if (operationId == 10)
           operation = "";  // If we get the index 10 it means we deal with input
                            // that have empty string as operation and so that we
@@ -84,9 +84,9 @@ void Settings::loadSettings() {
       d_operationsToHierarchy[operationId] = operations;
     }
 
-    int operationsCount;
+    uint32_t operationsCount;
     readFile >> operationsCount;
-    for (int i = 0; i < operationsCount; ++i) {
+    for (uint32_t i = 0; i < operationsCount; ++i) {
       std::string fromName, toName;
       readFile >> fromName;
       if (fromName == "input") {
@@ -108,7 +108,7 @@ std::string Settings::getInstanceName() const {
   return d_name;
 }
 
-std::pair<std::string, int> Settings::getLogicOperation(const std::string& i_op
+std::pair<std::string, int32_t> Settings::getLogicOperation(const std::string& i_op
 ) {
   return d_logicOperations.at(i_op);
 }
@@ -128,7 +128,7 @@ std::pair<std::vector<bool>, std::vector<Gates>>
   return std::make_pair(oneGate, d_logicElements);
 }
 
-int Settings::getNumThread() const {
+uint16_t Settings::getNumThread() const {
   return d_numThreads;
 }
 
@@ -140,7 +140,7 @@ std::string Settings::getNadezhdaVar(const std::string& key) const {
   return d_nadezhda.at(key);
 }
 
-std::vector<std::string> Settings::fromOperationsToHierarchy(int key) const {
+std::vector<std::string> Settings::fromOperationsToHierarchy(int32_t key) const {
   return d_operationsToHierarchy.at(key);
 }
 
@@ -205,15 +205,15 @@ std::string Settings::getLibraryNameFromEnum(const LibrariesTypes& library
   }
 }
 
-int Settings::getMaxInputs() const {
+uint32_t Settings::getMaxInputs() const {
   return d_maxInputs;
 }
 
-int Settings::getMaxOutputs() const {
+uint32_t Settings::getMaxOutputs() const {
   return d_maxOutputs;
 }
 
-std::map<std::string, std::pair<std::string, int>> Settings::getLogicOperations(
+std::map<std::string, std::pair<std::string, int32_t>> Settings::getLogicOperations(
 ) const {
   return d_logicOperations;
 }

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -67,7 +67,7 @@ void Settings::loadSettings() {
     int32_t operationHierarchyCount;
     readFile >> operationHierarchyCount;
     for (int32_t i = 0; i < operationHierarchyCount; ++i) {
-      int32_t                      operationId, operationHierarchyCount;
+      int32_t                  operationId, operationHierarchyCount;
       std::vector<std::string> operations;
       readFile >> operationId >> operationHierarchyCount;
 
@@ -108,7 +108,8 @@ std::string Settings::getInstanceName() const {
   return d_name;
 }
 
-std::pair<std::string, int32_t> Settings::getLogicOperation(const std::string& i_op
+std::pair<std::string, int32_t> Settings::getLogicOperation(
+    const std::string& i_op
 ) {
   return d_logicOperations.at(i_op);
 }
@@ -140,7 +141,8 @@ std::string Settings::getNadezhdaVar(const std::string& key) const {
   return d_nadezhda.at(key);
 }
 
-std::vector<std::string> Settings::fromOperationsToHierarchy(int32_t key) const {
+std::vector<std::string> Settings::fromOperationsToHierarchy(int32_t key
+) const {
   return d_operationsToHierarchy.at(key);
 }
 
@@ -213,8 +215,8 @@ uint32_t Settings::getMaxOutputs() const {
   return d_maxOutputs;
 }
 
-std::map<std::string, std::pair<std::string, int32_t>> Settings::getLogicOperations(
-) const {
+std::map<std::string, std::pair<std::string, int32_t>>
+    Settings::getLogicOperations() const {
   return d_logicOperations;
 }
 

--- a/src/settings/Settings.hpp
+++ b/src/settings/Settings.hpp
@@ -165,7 +165,7 @@ public:
   /// @throws std::out_of_range If the passed operation name does not exist
   /// in the list of logical operations
 
-  std::pair<std::string, int32_t>      getLogicOperation(const std::string& i_op);
+  std::pair<std::string, int32_t>  getLogicOperation(const std::string& i_op);
 
   /// @brief getLogicOperationsKeys Returns the keys of logical operations
   /// @return std::vector<Gates> A vector containing the keys of logical
@@ -287,12 +287,12 @@ public:
   /// @brief getMaxInputs Gets the maximum number of inputs
   /// @return uint32_t Maximum number of inputs
 
-  uint32_t         getMaxInputs() const;
+  uint32_t    getMaxInputs() const;
 
   /// @brief getMaxOutputs Returns the maximum number of outputs
   /// @return uint32_t Maximum number of outputs
 
-  uint32_t         getMaxOutputs() const;
+  uint32_t    getMaxOutputs() const;
 
   /// @brief getLogicOperations all logical operations
   /// The method returns a dictionary containing all logical operations
@@ -304,12 +304,13 @@ public:
   /// @return std::map<std::string, std::pair<std::string, int32_t>> Dictionary
   /// with logical operations
 
-  std::map<std::string, std::pair<std::string, int32_t>> getLogicOperations() const;
+  std::map<std::string, std::pair<std::string, int32_t>> getLogicOperations(
+  ) const;
 
   /// @brief getPathNadezhda Returns the path to Nadezhda
   /// @return std::string Path to Nadezhda
 
-  std::string                                        getPathNadezhda() const;
+  std::string              getPathNadezhda() const;
 
   /// @brief getNadezhdaVar Gets the value of a variable from the Nadezhda
   /// dictionary by key
@@ -354,7 +355,7 @@ public:
   /// std::cout << "Number of threads: " << numThreads << std::endl;
   /// @endcode
 
-  uint16_t                      getNumThread() const;
+  uint16_t                 getNumThread() const;
 
   /// @brief parseStringToGate Converts a string representation of a gate to
   /// its corresponding enum value
@@ -442,7 +443,7 @@ private:
       {"resynthesis", "Nadezhda/Scripts/resynthesis_local_rewriting.pyc"},
       {"reliability", "Nadezhda/Scripts/check_reliability.pyc"},
       {"liberty", "Nadezda/Test/Nangate.lib"}};
-  uint16_t                                                d_numThreads      = 4;
+  uint16_t                                               d_numThreads      = 4;
   std::map<std::string, std::pair<std::string, int32_t>> d_logicOperations = {
       {"input", {"", 10}},
       {"output", {"=", 0}},
@@ -514,7 +515,7 @@ private:
       {GenerationTypes::ALU, "CCGALU"}};
 
   std::map<int32_t, std::vector<std::string>> d_operationsToHierarchy;
-  std::map<std::string, std::string>      d_operationsToName;
-  uint32_t                                     d_maxInputs  = 50;
-  uint32_t                                     d_maxOutputs = 50;
+  std::map<std::string, std::string>          d_operationsToName;
+  uint32_t                                    d_maxInputs  = 50;
+  uint32_t                                    d_maxOutputs = 50;
 };

--- a/src/settings/Settings.hpp
+++ b/src/settings/Settings.hpp
@@ -146,13 +146,13 @@ public:
   /// @brief getLogicOperation Gets information about a logical operation by
   /// its name
   /// @param i_op A string containing the name of the logical operation
-  /// @return std::pair<std::string, int> A pair containing the name and ID
+  /// @return std::pair<std::string, int32_t> A pair containing the name and ID
   /// of the logical operation
   /// @code
   /// Settings settingsInstance;
   /// try {
   /// // Get information about the logical operation "and"
-  /// std::pair<std::string, int> operationInfo =
+  /// std::pair<std::string, int32_t> operationInfo =
   /// settingsInstance.getLogicOperation("and");
   /// // Output information about the logical operation
   /// std::cout << "Operation name: " << operationInfo.first << std::endl;
@@ -165,7 +165,7 @@ public:
   /// @throws std::out_of_range If the passed operation name does not exist
   /// in the list of logical operations
 
-  std::pair<std::string, int>      getLogicOperation(const std::string& i_op);
+  std::pair<std::string, int32_t>      getLogicOperation(const std::string& i_op);
 
   /// @brief getLogicOperationsKeys Returns the keys of logical operations
   /// @return std::vector<Gates> A vector containing the keys of logical
@@ -285,14 +285,14 @@ public:
   std::string getLibraryNameFromEnum(const LibrariesTypes& library) const;
 
   /// @brief getMaxInputs Gets the maximum number of inputs
-  /// @return int Maximum number of inputs
+  /// @return uint32_t Maximum number of inputs
 
-  int         getMaxInputs() const;
+  uint32_t         getMaxInputs() const;
 
   /// @brief getMaxOutputs Returns the maximum number of outputs
-  /// @return int Maximum number of outputs
+  /// @return uint32_t Maximum number of outputs
 
-  int         getMaxOutputs() const;
+  uint32_t         getMaxOutputs() const;
 
   /// @brief getLogicOperations all logical operations
   /// The method returns a dictionary containing all logical operations
@@ -301,10 +301,10 @@ public:
   /// element is a string representing the name of the operation, and the
   /// second element is an integer value representing the identifier of
   /// the operation
-  /// @return std::map<std::string, std::pair<std::string, int>> Dictionary
+  /// @return std::map<std::string, std::pair<std::string, int32_t>> Dictionary
   /// with logical operations
 
-  std::map<std::string, std::pair<std::string, int>> getLogicOperations() const;
+  std::map<std::string, std::pair<std::string, int32_t>> getLogicOperations() const;
 
   /// @brief getPathNadezhda Returns the path to Nadezhda
   /// @return std::string Path to Nadezhda
@@ -341,20 +341,20 @@ public:
   /// @throws std::out_of_range If the provided key does not exist in the
   /// internal map of operation keys to hierarchies
 
-  std::vector<std::string> fromOperationsToHierarchy(int key) const;
+  std::vector<std::string> fromOperationsToHierarchy(int32_t key) const;
 
   /// @brief getNumThread Retrieves the number of threads used for processing
-  /// @return int The number of threads configured for processing
+  /// @return uint16_t The number of threads configured for processing
   /// @code
   /// // Creating an instance of the Settings class or getting it from an
   /// existing object std::shared_ptr<Settings> settingsInstance =
   /// Settings::getInstance("/path/to/settings");
   /// // Get the number of threads configured for processing
-  /// int numThreads = settingsInstance->getNumThread();
+  /// uint16_t numThreads = settingsInstance->getNumThread();
   /// std::cout << "Number of threads: " << numThreads << std::endl;
   /// @endcode
 
-  int                      getNumThread() const;
+  uint16_t                      getNumThread() const;
 
   /// @brief parseStringToGate Converts a string representation of a gate to
   /// its corresponding enum value
@@ -442,8 +442,8 @@ private:
       {"resynthesis", "Nadezhda/Scripts/resynthesis_local_rewriting.pyc"},
       {"reliability", "Nadezhda/Scripts/check_reliability.pyc"},
       {"liberty", "Nadezda/Test/Nangate.lib"}};
-  int                                                d_numThreads      = 4;
-  std::map<std::string, std::pair<std::string, int>> d_logicOperations = {
+  uint16_t                                                d_numThreads      = 4;
+  std::map<std::string, std::pair<std::string, int32_t>> d_logicOperations = {
       {"input", {"", 10}},
       {"output", {"=", 0}},
       {"const", {"1'b0", 9}},
@@ -513,8 +513,8 @@ private:
       {GenerationTypes::Decoder, "CCGDCR"},
       {GenerationTypes::ALU, "CCGALU"}};
 
-  std::map<int, std::vector<std::string>> d_operationsToHierarchy;
+  std::map<int32_t, std::vector<std::string>> d_operationsToHierarchy;
   std::map<std::string, std::string>      d_operationsToName;
-  int                                     d_maxInputs  = 50;
-  int                                     d_maxOutputs = 50;
+  uint32_t                                     d_maxInputs  = 50;
+  uint32_t                                     d_maxOutputs = 50;
 };

--- a/test/src/additional/AuxiliaryMethodsTests.cpp
+++ b/test/src/additional/AuxiliaryMethodsTests.cpp
@@ -107,15 +107,15 @@ TEST(
 
 TEST(TestAuxiliarySortDictByValue, NormalTest) {
   // Just created some maps that going to be input for  sortDictByValue
-  std::map<std::string, int> normalInput1 = {
+  std::map<std::string, int32_t> normalInput1 = {
       {"0", 0}, {"1", 1}, {"2", 2}, {"3", 3}};
-  std::map<std::string, int> normalInput2 = {
+  std::map<std::string, int32_t> normalInput2 = {
       {"0", 110}, {"1", 10}, {"2", 20}, {"3", 3}};
-  std::map<std::string, int> normalInput3 = {
+  std::map<std::string, int32_t> normalInput3 = {
       {"0", 1100}, {"1", 1}, {"2", 1}, {"3", 33}};
   // Here I created vector correctAnswer which I will use to compare with the
   // result of sortDictByValue
-  std::vector<std::pair<std::string, int>> correctAnswer;
+  std::vector<std::pair<std::string, int32_t>> correctAnswer;
   // Here I fill the vector with expected from sortDictByValue(testDict1, false)
   // data
   correctAnswer.push_back({"3", 3});
@@ -156,7 +156,7 @@ TEST(
     SortDictByValueReturnEmptyVectorWhenThereEmptyDictionary
 ) {
   // Just created a map that going to be input for  sortDictByValue
-  std::map<std::string, int> EmptyMap = {};
+  std::map<std::string, int32_t> EmptyMap = {};
   EXPECT_EQ(
       0, (sortDictByValue(EmptyMap, true)).size()
   );  // Check to make sure that output of sortDictByValue(testDict1, true) has
@@ -169,11 +169,11 @@ TEST(
 
 TEST(TestAuxiliarySortDictByValue, WhenThereTheSameValuesInDictionary) {
   // Just created a map that's going to be input for  sortDictByValue
-  std::map<std::string, int> TheSameElements = {
+  std::map<std::string, int32_t> TheSameElements = {
       {"1", 1}, {"2", 1}, {"3", 1}, {"4", 1}, {"5", 1}};
   // Here I created vector correctAnswer which I will use to compare with the
   // result of sortDictByValue
-  std::vector<std::pair<std::string, int>> correctAnswer;
+  std::vector<std::pair<std::string, int32_t>> correctAnswer;
   // Here I fill the vector with expected from sortDictByValue(testDict1, false)
   // data
   correctAnswer.push_back({"1", 1});

--- a/test/src/additional/filesTools/FilesToolsTests.cpp
+++ b/test/src/additional/filesTools/FilesToolsTests.cpp
@@ -89,7 +89,7 @@ TEST(FileTools, NoDirectoriesOnlyFiles) {
 
   // Created ten empty txt files in the current directory to make sure that the
   // function does not count files.
-  for (int i = 1; i <= 10; i++) {
+  for (int32_t i = 1; i <= 10; i++) {
     std::ofstream file;
     std::string   str = std::to_string(i)
                     + ".txt";  // Create str to prevent warning from below line
@@ -147,7 +147,7 @@ TEST(FileTools, DirectoriesAndFilesExist) {
 
   // Created ten empty txt files in the current directory to make sure that the
   // function does not count files.
-  for (int i = 1; i <= 10; i++) {
+  for (int32_t i = 1; i <= 10; i++) {
     std::ofstream file;
     std::string   str =
         std::to_string(i) + ".txt";  // To prevent warning from below line

--- a/test/src/baseStructures/graph/OrientedGraphTests.cpp
+++ b/test/src/baseStructures/graph/OrientedGraphTests.cpp
@@ -76,13 +76,13 @@ TEST(TestBaseSizeAndFullSizeAndSumFullSize, ReturnCorrectSize) {
   EXPECT_EQ(graphPtr->fullSize(), 18);
   EXPECT_EQ(graphPtr->sumFullSize(), 24);
 
-  GraphPtr subGrpahPtr1 = std::make_shared<OrientedGraph>();
-  subGrpahPtr1->addGate(Gates::GateAnd, "Anything");
-  subGrpahPtr1->addInput("Anything");
-  subGrpahPtr1->addOutput("Anything");
-  subGrpahPtr1->addConst('x', "Anything");
+  GraphPtr subGraphPtr1 = std::make_shared<OrientedGraph>();
+  subGraphPtr1->addGate(Gates::GateAnd, "Anything");
+  subGraphPtr1->addInput("Anything");
+  subGraphPtr1->addOutput("Anything");
+  subGraphPtr1->addConst('x', "Anything");
   graphPtr->addSubGraph(
-      subGrpahPtr1, subGrpahPtr1->getVerticesByType(VertexTypes::input)
+      subGraphPtr1, subGraphPtr1->getVerticesByType(VertexTypes::input)
   );
 
   EXPECT_EQ(graphPtr->baseSize(), 18);
@@ -90,13 +90,13 @@ TEST(TestBaseSizeAndFullSizeAndSumFullSize, ReturnCorrectSize) {
   // Does sumFullSize() return sum from subGraphs too
   // EXPECT_EQ(graphPtr->sumFullSize(), 28);
 
-  GraphPtr subGrpahPtr2 = std::make_shared<OrientedGraph>("");
-  subGrpahPtr2->addGate(Gates::GateAnd, "Anything");
-  subGrpahPtr2->addInput("Anything");
-  subGrpahPtr2->addOutput("Anything");
-  subGrpahPtr2->addConst('x', "Anything");
+  GraphPtr subGraphPtr2 = std::make_shared<OrientedGraph>("");
+  subGraphPtr2->addGate(Gates::GateAnd, "Anything");
+  subGraphPtr2->addInput("Anything");
+  subGraphPtr2->addOutput("Anything");
+  subGraphPtr2->addConst('x', "Anything");
   graphPtr->addSubGraph(
-      subGrpahPtr2, subGrpahPtr2->getVerticesByType(VertexTypes::input)
+      subGraphPtr2, subGraphPtr2->getVerticesByType(VertexTypes::input)
   );
   EXPECT_EQ(graphPtr->baseSize(), 18);
   EXPECT_EQ(graphPtr->fullSize(), 20);
@@ -396,7 +396,7 @@ TEST(TestGetVerticesByName, ReturnCorrectVertices) {
   );
 }
 
-TEST(TestToGraphMLStringReturn, ReturnCorrectStringWhenGrpahIsEmpty) {
+TEST(TestToGraphMLStringReturn, ReturnCorrectStringWhenGraphIsEmpty) {
   GraphPtr graphPtr = std::make_shared<OrientedGraph>("Graph1");
   EXPECT_EQ(graphPtr->isEmptyFull(), true);
   EXPECT_EQ(

--- a/test/src/baseStructures/graph/OrientedGraphTests.cpp
+++ b/test/src/baseStructures/graph/OrientedGraphTests.cpp
@@ -530,8 +530,8 @@ TEST(TestToGraphMLStringReturn, ReturnCorrectStringWhenThereAreSubEdges) {
       "    <node id=\"gate1\">\n"
       "      <data key=\"d0\">and</data>\n"
       "    </node>\n"
-      "    <source=\"input1\" target=\"gate1\"/>\n"
-      "    <source=\"input2\" target=\"gate1\"/>\n"
+      "    <edge source=\"input1\" target=\"gate1\"/>\n"
+      "    <edge source=\"input2\" target=\"gate1\"/>\n"
       "  </graph>\n"
       "</graphml>\n"
   );

--- a/test/src/baseStructures/truthTable/TruthTableTests.cpp
+++ b/test/src/baseStructures/truthTable/TruthTableTests.cpp
@@ -112,7 +112,7 @@ TEST(GenerateTableOfTruthTable, CorrectSizeOfVector) {
   TruthTable example = TruthTable {1, 2, 0.2};
   example.generateTable();
   EXPECT_EQ(example.getOutTable().size(), 2);
-  for (int i = 0; i < 2; i++) {
+  for (int32_t i = 0; i < 2; i++) {
     EXPECT_EQ(example.getOutTable()[i].size(), 2);
   }
 }

--- a/test/src/database/DataBaseGeneratorTests.cpp
+++ b/test/src/database/DataBaseGeneratorTests.cpp
@@ -65,7 +65,7 @@ TEST(GenerateDataBaseFromRandomTruthTable, EqualWithTheSameSeeds) {
   //   );
   // }
 
-  for (int i = 0; i < part1.size(); ++i) {
+  for (size_t i = 0; i < part1.size(); ++i) {
     EXPECT_EQ(part1[i]->calculateHash(), part2[i]->calculateHash());
   }
 
@@ -94,7 +94,7 @@ TEST(GenerateDataBaseFromRandomTruthTable, EqualWithTheSameSeeds) {
   // ASSERT_EQ(jsons1.empty(), false);
   // ASSERT_EQ(jsons1.size(), jsons2.size());
 
-  for (int i = 0; i < part3.size(); ++i) {
+  for (size_t i = 0; i < part3.size(); ++i) {
     EXPECT_EQ(part3[i]->calculateHash(), part4[i]->calculateHash());
   }
   std::filesystem::remove_all(mainDir + "/" + dir);
@@ -123,7 +123,7 @@ TEST(GenerateDataBaseRandLevel, EqualWithTheSameSeeds) {
   ASSERT_EQ(jsons1.empty(), false);
   ASSERT_EQ(jsons1.size(), jsons2.size());
 
-  for (int i = 0; i < jsons1.size(); ++i) {
+  for (size_t i = 0; i < jsons1.size(); ++i) {
     EXPECT_EQ(
         FilesTools::loadStringFile(jsons1[i]),
         FilesTools::loadStringFile(jsons2[i])
@@ -149,7 +149,7 @@ TEST(GenerateDataBaseRandLevel, EqualWithTheSameSeeds) {
   ASSERT_EQ(jsons1.empty(), false);
   ASSERT_EQ(jsons1.size(), jsons2.size());
 
-  for (int i = 0; i < jsons1.size(); ++i) {
+  for (size_t i = 0; i < jsons1.size(); ++i) {
     EXPECT_EQ(
         FilesTools::loadStringFile(jsons1[i]),
         FilesTools::loadStringFile(jsons2[i])
@@ -229,7 +229,7 @@ TEST(GenerateDataBaseRandLevelExperimental, EqualWithTheSameSeeds) {
   ASSERT_EQ(jsons1.empty(), false);
   ASSERT_EQ(jsons1.size(), jsons2.size());
 
-  for (int i = 0; i < jsons1.size(); ++i) {
+  for (size_t i = 0; i < jsons1.size(); ++i) {
     EXPECT_EQ(
         FilesTools::loadStringFile(jsons1[i]),
         FilesTools::loadStringFile(jsons2[i])
@@ -259,7 +259,7 @@ TEST(GenerateDataBaseRandLevelExperimental, EqualWithTheSameSeeds) {
   ASSERT_EQ(jsons1.empty(), false);
   ASSERT_EQ(jsons1.size(), jsons2.size());
 
-  for (int i = 0; i < jsons1.size(); ++i) {
+  for (size_t i = 0; i < jsons1.size(); ++i) {
     EXPECT_EQ(
         FilesTools::loadStringFile(jsons1[i]),
         FilesTools::loadStringFile(jsons2[i])

--- a/test/src/generators/simple/SimpleGeneratorsTests.cpp
+++ b/test/src/generators/simple/SimpleGeneratorsTests.cpp
@@ -51,7 +51,7 @@ TEST(CnfFromTruthTableTest, EqualWithTheSameParametrs) {
 
 // RnadLevel
 TEST(GeneratorRandLevelTest, EqualWithTheSameParametrs) {
-  std::map<std::string, std::vector<int>> gatesInfo = {
+  std::map<std::string, std::vector<int32_t>> gatesInfo = {
       {"and", {2, 4, 8}},
       {"nand", {2, 4, 8}},
       {"or", {2, 8}},
@@ -95,7 +95,7 @@ TEST(GeneratorRandLevelTest, EqualWithTheSameParametrs) {
 
 // RandLevelExperimental
 TEST(GeneratorRandLevelExperimentalTest, EqualWithTheSameParametrs) {
-  std::map<std::string, std::vector<int>> gatesInfo = {
+  std::map<std::string, std::vector<int32_t>> gatesInfo = {
       {"and", {2, 4, 8}},
       {"nand", {2, 4, 8}},
       {"or", {2, 8}},
@@ -140,12 +140,12 @@ TEST(GeneratorRandLevelExperimentalTest, EqualWithTheSameParametrs) {
 
 // NumOperations
 TEST(GeneratorNumOperationsTest, EqualWithTheSameParametrs) {
-  SimpleGenerators     generator1 = SimpleGenerators(1);
-  SimpleGenerators     generator2 = SimpleGenerators(1);
-  SimpleGenerators     generator3 = SimpleGenerators(2);
-  SimpleGenerators     generator4 = SimpleGenerators(2);
+  SimpleGenerators         generator1 = SimpleGenerators(1);
+  SimpleGenerators         generator2 = SimpleGenerators(1);
+  SimpleGenerators         generator3 = SimpleGenerators(2);
+  SimpleGenerators         generator4 = SimpleGenerators(2);
 
-  std::map<Gates, int> logicOper  = {
+  std::map<Gates, int32_t> logicOper  = {
       {Gates::GateAnd, 2}, {Gates::GateOr, 2}, {Gates::GateNot, 1}};
   std::shared_ptr<OrientedGraph> graphPtr1 =
       generator1.generatorNumOperation(1, 1, logicOper, true);
@@ -298,13 +298,13 @@ TEST(GeneratorComparisonTest, DifferentFromEachOther) {
   EXPECT_FALSE(str1 == str2);
 }
 TEST(GeneratorComparisonTest, GraphSizeTest) {
-  int              bits = 1;
+  uint32_t         bits = 1;
   SimpleGenerators generator;
   GraphPtr graph = generator.generatorComparison(bits, true, false, false);
 
   ASSERT_NE(graph, nullptr);
 
-  int expectedVertexCount = 8;
+  size_t expectedVertexCount = 8;
   EXPECT_EQ(graph->sumFullSize(), expectedVertexCount);
   // graph->~OrientedGraph();
 }
@@ -369,7 +369,7 @@ TEST(GeneratorSummatorTest, DifferentFromEachOther) {
 TEST(GeneratorSummatorTest, NumOfElements) {
   SimpleGenerators S_gen_1(1);
   SimpleGenerators S_gen_2(1);
-  int              bits = 1;
+  uint32_t         bits = 1;
   GraphPtr graph_1      = S_gen_1.generatorSummator(bits, false, false, false);
   EXPECT_EQ(graph_1->sumFullSize(), 6);
   bits             = 4;

--- a/test/src/settings/SettingsTests.cpp
+++ b/test/src/settings/SettingsTests.cpp
@@ -54,7 +54,7 @@ TEST(TestSettings, TestDefaultLoadSettings) {
   std::shared_ptr<Settings> t =
       Settings::getInstance("test_default_load_settings");
 
-  std::map<int, std::vector<std::string>> operToHierAns;
+  std::map<int32_t, std::vector<std::string>> operToHierAns;
   operToHierAns[0]  = {"="};
   operToHierAns[1]  = {"xnor"};
   operToHierAns[2]  = {"xor"};
@@ -99,18 +99,19 @@ TEST(
         Settings::getInstance(" ");  // Here we call implicitly loadSettings.
     // Below I going to write down correct samples that I want to use to compare
     // with the output of the loadSettings
-    std::map<std::string, std::pair<std::string, int>> correctLogicOperations =
-        {{"input", {"", 10}},
-         {"output", {"=", 0}},
-         {"const", {"1'b0", 9}},
-         {"and", {"and", 4}},
-         {"nand", {"nand", 3}},
-         {"or", {"or", 6}},
-         {"nor", {"nor", 5}},
-         {"not", {"not", 7}},
-         {"buf", {"buf", 8}},
-         {"xor", {"xor", 2}},
-         {"xnor", {"xnor", 1}}};
+    std::map<std::string, std::pair<std::string, int32_t>>
+        correctLogicOperations = {
+            {"input", {"", 10}},
+            {"output", {"=", 0}},
+            {"const", {"1'b0", 9}},
+            {"and", {"and", 4}},
+            {"nand", {"nand", 3}},
+            {"or", {"or", 6}},
+            {"nor", {"nor", 5}},
+            {"not", {"not", 7}},
+            {"buf", {"buf", 8}},
+            {"xor", {"xor", 2}},
+            {"xnor", {"xnor", 1}}};
 
     for (auto const& [key, val] : correctLogicOperations) {
       EXPECT_EQ(correctLogicOperations[key], SetPtr->getLogicOperation(key));
@@ -127,7 +128,7 @@ TEST(
         Settings::getInstance(" ");  // Here we call implicitly loadSettings.
     // Below I going to write down correct samples that I want to use to compare
     // with the output of the loadSettings
-    std::map<int, std::vector<std::string>> correctOperationsToHierarchy = {
+    std::map<int32_t, std::vector<std::string>> correctOperationsToHierarchy = {
         {10, {""}},
         {0, {"="}},
         {9, {"1'b0"}},


### PR DESCRIPTION
Все типы int и unsigned заменены на int32_t, uint32_t и т.д. (кроме файлов empty_example.cpp, UnboundedMPMCQueue.hpp, json.hpp, main.cpp и комментариев). Многие int заменены на uint-варианты (uint32_t, uint16_t, size_t и т.д.). Исправлен один шаблон для GraphML. Включил также фикс сида в режиме многопоточности от Ильи. Изменений в работоспособности по сравнению с текущим мейном нет (однако баги не исключены полностью).